### PR TITLE
Refactor blog CSS variables to use media queries

### DIFF
--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -77,11 +77,7 @@
 		margin: 0 auto;
 		margin-top: 80px; /* More space from top */
 		padding: var(--blog-spacing-lg) var(--blog-spacing-sm);
-		color: var(--blog-text-light);
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-text-dark);
-		}
+		color: var(--blog-text);
 
 		@media (min-width: 640px) {
 			padding: var(--blog-spacing-lg) var(--blog-spacing-md);

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -169,7 +169,7 @@
 	.blog-subtitle {
 		max-width: var(--blog-subtitle-width);
 		margin: 0 0 var(--blog-spacing-lg) 0;
-		color: var(--blog-accent-light);
+		color: var(--blog-accent);
 		font-style: italic;
 		font-size: var(--blog-body);
 		line-height: 1.75rem;
@@ -178,10 +178,6 @@
 		@media (min-width: 768px) {
 			font-size: var(--blog-body-large);
 			line-height: 2.25rem;
-		}
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-accent-dark);
 		}
 	}
 

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -210,10 +210,11 @@
 		height: 16px;
 		min-width: 16px;
 		color: currentColor;
+		fill: currentColor !important;
 	}
 
-	.clock-icon path {
-		fill: currentColor;
+	.clock-icon * {
+		fill: currentColor !important;
 	}
 
 	.publish-date {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -129,10 +129,11 @@
 		height: 16px;
 		min-width: 16px;
 		color: currentColor;
+		fill: currentColor !important;
 	}
 
-	.back-icon path {
-		fill: currentColor;
+	.back-icon * {
+		fill: currentColor !important;
 	}
 
 	.breadcrumb-separator {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -137,11 +137,7 @@
 
 	.breadcrumb-category {
 		font-weight: 500;
-		color: var(--blog-secondary-light);
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-secondary-dark);
-		}
+		color: var(--blog-secondary);
 	}
 
 	/* Title */

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -131,6 +131,10 @@
 		color: currentColor;
 	}
 
+	.back-icon path {
+		fill: currentColor;
+	}
+
 	.breadcrumb-separator {
 		color: var(--blog-secondary);
 	}

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -205,8 +205,12 @@
 		display: flex;
 		align-items: center;
 		gap: 6px;
-		color: var(--blog-secondary);
+		color: var(--blog-secondary) !important;
 		font-size: var(--blog-body-small);
+	}
+
+	.reading-time span {
+		color: inherit !important;
 	}
 
 	.clock-icon {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -114,12 +114,12 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;
-		color: var(--blog-link) !important;
+		color: var(--blog-secondary) !important;
 		text-decoration: none;
 		font-weight: 500;
 
 		&:hover {
-			color: var(--blog-link-hover) !important;
+			color: var(--blog-link) !important;
 			text-decoration: underline;
 		}
 	}

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -210,11 +210,11 @@
 		height: 16px;
 		min-width: 16px;
 		color: currentColor;
-		fill: currentColor !important;
 	}
 
-	.clock-icon * {
+	.reading-time .clock-icon path {
 		fill: currentColor !important;
+		color: inherit !important;
 	}
 
 	.publish-date {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -114,21 +114,13 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;
-		color: var(--blog-link-light);
+		color: var(--blog-link);
 		text-decoration: none;
 		font-weight: 500;
 
 		&:hover {
-			color: var(--blog-link-hover-light);
+			color: var(--blog-link-hover);
 			text-decoration: underline;
-		}
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-link-dark);
-
-			&:hover {
-				color: var(--blog-link-hover-dark);
-			}
 		}
 	}
 

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -196,12 +196,8 @@
 		display: flex;
 		align-items: center;
 		gap: 6px;
-		color: var(--blog-secondary-light);
+		color: var(--blog-secondary);
 		font-size: var(--blog-body-small);
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-secondary-dark);
-		}
 	}
 
 	.clock-icon {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -114,14 +114,18 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 6px;
-		color: var(--blog-link);
+		color: var(--blog-link) !important;
 		text-decoration: none;
 		font-weight: 500;
 
 		&:hover {
-			color: var(--blog-link-hover);
+			color: var(--blog-link-hover) !important;
 			text-decoration: underline;
 		}
+	}
+
+	.breadcrumb-link span {
+		color: inherit !important;
 	}
 
 	.back-icon {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -145,7 +145,7 @@
 		font-size: 2.25rem;
 		line-height: 2.5rem;
 		margin: 0 0 var(--blog-spacing-sm) 0;
-		color: var(--blog-heading-light);
+		color: var(--blog-heading);
 		font-weight: 500;
 		font-family: 'Spectral', serif;
 
@@ -162,10 +162,6 @@
 		@media (min-width: 1024px) {
 			font-size: 4.5rem;
 			line-height: 1;
-		}
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-heading-dark);
 		}
 	}
 

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -208,12 +208,8 @@
 	}
 
 	.publish-date {
-		color: var(--blog-secondary-light);
+		color: var(--blog-secondary);
 		font-size: var(--blog-body-small);
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-secondary-dark);
-		}
 	}
 
 	/* Responsive Design */

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -132,11 +132,7 @@
 	}
 
 	.breadcrumb-separator {
-		color: var(--blog-secondary-light);
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-secondary-dark);
-		}
+		color: var(--blog-secondary);
 	}
 
 	.breadcrumb-category {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -107,11 +107,7 @@
 		gap: 6px;
 		margin-bottom: var(--blog-spacing-md);
 		font-size: var(--blog-body-small);
-		color: var(--blog-secondary-light);
-
-		@media (prefers-color-scheme: dark) {
-			color: var(--blog-secondary-dark);
-		}
+		color: var(--blog-secondary);
 	}
 
 	.breadcrumb-link {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -188,12 +188,8 @@
 		gap: var(--blog-spacing-md);
 		margin-bottom: var(--blog-spacing-md);
 		padding-bottom: var(--blog-spacing-md);
-		border-bottom: 1px solid var(--blog-border-light);
+		border-bottom: 1px solid var(--blog-border);
 		flex-wrap: wrap;
-
-		@media (prefers-color-scheme: dark) {
-			border-bottom-color: var(--blog-border-dark);
-		}
 	}
 
 	.reading-time {

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -211,6 +211,10 @@
 		color: currentColor;
 	}
 
+	.clock-icon path {
+		fill: currentColor;
+	}
+
 	.publish-date {
 		color: var(--blog-secondary);
 		font-size: var(--blog-body-small);

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -129,11 +129,11 @@
 		height: 16px;
 		min-width: 16px;
 		color: currentColor;
-		fill: currentColor !important;
 	}
 
-	.back-icon * {
+	.breadcrumb-link .back-icon path {
 		fill: currentColor !important;
+		color: inherit !important;
 	}
 
 	.breadcrumb-separator {

--- a/src/routes/(landing-pages)/blog/+layout.svelte
+++ b/src/routes/(landing-pages)/blog/+layout.svelte
@@ -25,7 +25,32 @@
 		--blog-mention: #0f766e;
 		--blog-equation: #4b5563;
 		--blog-border: #939599;
+	}
 
+	/* Dark mode overrides */
+	:global(:root) {
+		@media (prefers-color-scheme: dark) {
+			--blog-text: #e5e7eb;
+			--blog-bg: #141414;
+			--blog-link: #67e8f9;
+			--blog-link-hover: #a5f3fc;
+			--blog-accent: #d1d5db;
+			--blog-secondary: #d1d5db;
+			--blog-heading: #f3f4f6;
+			--blog-callout: #1f2937;
+			--blog-quote-bg: #1f2937;
+			--blog-code-bg: #141414;
+			--blog-inline-code-bg: #1f2937;
+			--blog-code-tag: #f87171;
+			--blog-code-property: #e5e7eb;
+			--blog-divider: #4b5563;
+			--blog-mention: #34d399;
+			--blog-equation: #d1d5db;
+			--blog-border: #686a6c;
+		}
+	}
+
+	:global(:root) {
 		/* Typography */
 		--blog-heading-large: 3.75rem;
 		--blog-heading-medium: 2.25rem;

--- a/src/routes/(landing-pages)/blog/+layout.svelte
+++ b/src/routes/(landing-pages)/blog/+layout.svelte
@@ -5,43 +5,26 @@
 <slot />
 
 <style>
-	/* Define CSS variables for blog */
+	/* Define CSS variables for blog with proper media queries */
 	:global(:root) {
-		/* Colors */
-		--blog-text-light: #111827;
-		--blog-text-dark: #e5e7eb;
-		--blog-bg-light: #e5e7eb;
-		--blog-bg-dark: #141414;
-		--blog-link-light: #31676c;
-		--blog-link-dark: #67e8f9;
-		--blog-link-hover-dark: #a5f3fc;
-		--blog-accent-light: #374151;
-		--blog-accent-dark: #d1d5db;
-		--blog-secondary-light: #6b7280;
-		--blog-secondary-dark: #d1d5db;
-		--blog-secondary-dark: #9ca3af;
-		--blog-heading-light: #111827;
-		--blog-heading-dark: #f3f4f6;
-		--blog-callout-light: #d1d5db;
-		--blog-callout-dark: #1f2937;
-		--blog-quote-bg-light: #f3f4f6;
-		--blog-quote-bg-dark: #1f2937;
-		--blog-code-bg-light: #d1d5db;
-		--blog-code-bg-dark: #141414;
-		--blog-inline-code-bg-light: #e5e7eb;
-		--blog-inline-code-bg-dark: #1f2937;
-		--blog-code-tag-light: #0f766e;
-		--blog-code-tag-dark: #f87171;
-		--blog-code-property-light: #374151;
-		--blog-code-property-dark: #e5e7eb;
-		--blog-divider-light: #6b7280;
-		--blog-divider-dark: #4b5563;
-		--blog-mention-light: #0f766e;
-		--blog-mention-dark: #34d399;
-		--blog-equation-light: #4b5563;
-		--blog-equation-dark: #d1d5db;
-		--blog-border-light: #939599;
-		--blog-border-dark: #686a6c;
+		/* Colors for light mode */
+		--blog-text: #111827;
+		--blog-bg: #e5e7eb;
+		--blog-link: #31676c;
+		--blog-link-hover: #1e4042;
+		--blog-accent: #374151;
+		--blog-secondary: #6b7280;
+		--blog-heading: #111827;
+		--blog-callout: #d1d5db;
+		--blog-quote-bg: #f3f4f6;
+		--blog-code-bg: #d1d5db;
+		--blog-inline-code-bg: #e5e7eb;
+		--blog-code-tag: #0f766e;
+		--blog-code-property: #374151;
+		--blog-divider: #6b7280;
+		--blog-mention: #0f766e;
+		--blog-equation: #4b5563;
+		--blog-border: #939599;
 
 		/* Typography */
 		--blog-heading-large: 3.75rem;

--- a/src/routes/(landing-pages)/blog/+layout.svelte
+++ b/src/routes/(landing-pages)/blog/+layout.svelte
@@ -13,12 +13,12 @@
 		--blog-bg-light: #e5e7eb;
 		--blog-bg-dark: #141414;
 		--blog-link-light: #31676c;
-		--blog-link-dark: #a3e5eb;
-		--blog-link-hover-light: #1e4042;
-		--blog-link-hover-dark: #c7f7fc;
+		--blog-link-dark: #67e8f9;
+		--blog-link-hover-dark: #a5f3fc;
 		--blog-accent-light: #374151;
 		--blog-accent-dark: #d1d5db;
 		--blog-secondary-light: #6b7280;
+		--blog-secondary-dark: #d1d5db;
 		--blog-secondary-dark: #9ca3af;
 		--blog-heading-light: #111827;
 		--blog-heading-dark: #f3f4f6;

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -431,14 +431,10 @@
 			opacity: 0.8;
 			margin: var(--blog-spacing-xl) auto;
 			border: none;
-			border-top: 1px solid var(--blog-border-light);
+			border-top: 1px solid var(--blog-border);
 			width: auto;
 			max-width: var(--blog-content-width);
 			height: 1px;
-
-			@media (prefers-color-scheme: dark) {
-				border-top-color: var(--blog-border-dark);
-			}
 		}
 
 		:global(ol) {

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -425,10 +425,6 @@
 			li {
 				color: inherit;
 			}
-
-			@media (prefers-color-scheme: dark) {
-				color: var(--blog-text-dark);
-			}
 		}
 
 		:global(.notion-container hr) {

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -334,15 +334,11 @@
 		}
 
 		:global(.notion-container a) {
-			color: var(--blog-link-light);
+			color: var(--blog-link);
 			font-weight: 500;
 
 			&:hover {
 				text-decoration: underline;
-			}
-
-			@media (prefers-color-scheme: dark) {
-				color: var(--blog-link-dark);
 			}
 		}
 
@@ -350,7 +346,7 @@
 			border-radius: var(--blog-border-radius-sm);
 			background-color: var(--blog-code-bg);
 			padding: 0.2em 0.4em;
-			color: var(--blog-link-light);
+			color: var(--blog-link);
 		}
 
 		:global(.notion-container pre code) {

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -267,21 +267,7 @@
 			padding: var(--blog-spacing-xl) 25vw;
 		}
 
-		@media (prefers-color-scheme: dark) {
-			background-color: var(--blog-bg-dark);
-			color: var(--blog-text-dark);
 
-			:global(*) {
-				color: var(--blog-text-dark);
-			}
-
-			:global(a),
-			:global(code),
-			:global(.notion-container a),
-			:global(.notion-container code) {
-				color: var(--blog-link-dark);
-			}
-		}
 
 		:global(sub),
 		:global(sup) {

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -364,12 +364,8 @@
 			margin-top: var(--blog-spacing-lg);
 			margin-left: 2em;
 			max-width: var(--blog-blockquote-width);
-			color: var(--blog-callout-light);
+			color: var(--blog-callout);
 			font-style: italic;
-
-			@media (prefers-color-scheme: dark) {
-				color: var(--blog-secondary-dark);
-			}
 		}
 
 		:global(.notion-container .image) {

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -452,7 +452,7 @@
 			margin-top: var(--blog-spacing-lg);
 			margin-bottom: var(--blog-spacing-md);
 			border-radius: 0.5rem;
-			background-color: var(--blog-callout-light);
+			background-color: var(--blog-callout);
 			padding: var(--blog-spacing-lg) var(--blog-spacing-sm) var(--blog-spacing-md);
 
 			@media (min-width: 768px) {
@@ -475,10 +475,6 @@
 				@media (min-width: 768px) {
 					font-size: var(--blog-body);
 				}
-			}
-
-			@media (prefers-color-scheme: dark) {
-				background-color: var(--blog-callout-dark);
 			}
 		}
 

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -479,11 +479,7 @@
 		}
 
 		:global(.notion-container p, li) {
-			color: var(--blog-accent-light);
-
-			@media (prefers-color-scheme: dark) {
-				color: var(--blog-accent-dark);
-			}
+			color: var(--blog-accent);
 		}
 	}
 

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -321,12 +321,8 @@
 		a {
 			display: inline-block;
 			padding: var(--blog-spacing-md);
-			color: var(--blog-text-light);
+			color: var(--blog-text);
 			font-family: 'Spectral', serif;
-
-			@media (prefers-color-scheme: dark) {
-				color: var(--blog-text-dark);
-			}
 		}
 	}
 

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -393,7 +393,7 @@
 		:global(.notion-container h2) {
 			margin-top: 2.5em;
 			margin-bottom: 1.5em;
-			color: var(--blog-heading-light);
+			color: var(--blog-heading);
 			font-weight: 500;
 			font-size: var(--blog-heading-small);
 
@@ -404,25 +404,17 @@
 			@media (min-width: 1024px) {
 				font-size: 2.25rem;
 			}
-
-			@media (prefers-color-scheme: dark) {
-				color: var(--blog-heading-dark);
-			}
 		}
 
 		:global(.notion-container h3) {
 			margin-top: 1.5em;
 			margin-bottom: 1em;
-			color: var(--blog-heading-light);
+			color: var(--blog-heading);
 			font-weight: 500;
 			font-size: var(--blog-heading-small);
 
 			@media (min-width: 768px) {
 				font-size: var(--blog-heading-medium);
-			}
-
-			@media (prefers-color-scheme: dark) {
-				color: var(--blog-heading-dark);
 			}
 		}
 

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -229,29 +229,21 @@
 	:global(body) {
 		margin: 0;
 		padding: 0;
-		background-color: var(--blog-bg-light) !important;
+		background-color: var(--blog-bg) !important;
 		min-height: 100vh;
-
-		@media (prefers-color-scheme: dark) {
-			background-color: var(--blog-bg-dark) !important;
-		}
 	}
 
 	.page-wrapper {
 		min-height: 100vh;
-		background-color: var(--blog-bg-light);
+		background-color: var(--blog-bg);
 		position: relative;
 		z-index: 1;
-
-		@media (prefers-color-scheme: dark) {
-			background-color: var(--blog-bg-dark);
-		}
 	}
 
 	.blog-container {
-		background-color: var(--blog-bg-light);
+		background-color: var(--blog-bg);
 		padding: var(--blog-spacing-lg) var(--blog-spacing-sm);
-		color: var(--blog-text-light);
+		color: var(--blog-text);
 		max-width: 900px;
 		margin: 0 auto;
 


### PR DESCRIPTION
Refactors the blog component CSS variable system to use media queries instead of individual dark mode overrides.

Changes made:
- Consolidated CSS variables to use single names (e.g., `--blog-text` instead of `--blog-text-light`/`--blog-text-dark`)
- Moved dark mode color definitions to a single media query block in the layout file
- Removed individual `@media (prefers-color-scheme: dark)` blocks throughout components
- Updated all color references to use the simplified variable names
- Added `!important` declarations to ensure proper color inheritance for icons and spans

Files modified:
- `src/lib/components/blog-header.svelte`: Updated color variable references and removed dark mode media queries
- `src/routes/(landing-pages)/blog/+layout.svelte`: Consolidated variable definitions with centralized dark mode overrides
- `src/routes/(landing-pages)/blog/[slug]/+page.svelte`: Updated color references and removed redundant dark mode styles

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c228e088501b4a2ea9fbb00a46b750ec/pulse-home)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c228e088501b4a2ea9fbb00a46b750ec</projectId>-->
<!--<branchName>pulse-home</branchName>-->