### PR TITLE
Update subpage layout and image handling

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -40,6 +40,7 @@ li {
 
 body {
 	background-color: #fafafa;
+	overflow-x: hidden;
 }
 
 img {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -131,7 +131,7 @@
 		object-fit: cover;
 		object-position: center;
 		overflow: hidden;
-		filter: grayscale(1) sepia(0.3) hue-rotate(250deg) saturate(0.4);
+				filter: grayscale(1) sepia(0.5) hue-rotate(250deg) saturate(0.7);
 	}
 
 		@media (min-width: 1024px) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -122,7 +122,7 @@
 		height: 85vh;
 	}
 
-				.image-container img,
+					.image-container img,
 	.image-container :global(img) {
 		display: block;
 		border-radius: 1.5rem;
@@ -131,6 +131,7 @@
 		object-fit: cover;
 		object-position: center;
 		overflow: hidden;
+		filter: grayscale(1) sepia(0.3) hue-rotate(250deg) saturate(0.4);
 	}
 
 		@media (min-width: 1024px) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -121,12 +121,21 @@
 		min-height: 300px;
 	}
 
-		@media (max-width: 1023px) {
+			@media (max-width: 1023px) {
 		.image-container {
-			margin-left: calc(-50vw + 50%);
-			margin-right: calc(-50vw + 50%);
-			width: 100vw;
-			max-width: none;
+			margin-left: calc(-50vw + 50%) !important;
+			margin-right: calc(-50vw + 50%) !important;
+			width: 100vw !important;
+			max-width: none !important;
+		}
+	}
+
+	:global(.image-container) {
+		@media (max-width: 1023px) {
+			margin-left: calc(-50vw + 50%) !important;
+			margin-right: calc(-50vw + 50%) !important;
+			width: 100vw !important;
+			max-width: none !important;
 		}
 	}
 

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -114,12 +114,11 @@
 		margin-top: 3em;
 	}
 
-	.image-container {
-		position: sticky;
-		top: 7.5vh;
+		.image-container {
 		margin-right: auto;
 		margin-left: auto;
-		height: 85vh;
+		height: 50vh;
+		min-height: 300px;
 	}
 
 					.image-container img,

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -69,10 +69,17 @@
 </div>
 
 <style>
-	.container {
+		.container {
 		margin-right: auto;
 		margin-left: auto;
 		width: 75%;
+	}
+
+	@media (max-width: 1023px) {
+		.container {
+			width: 100%;
+			padding: 0;
+		}
 	}
 
 	h2 {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -130,7 +130,8 @@
 		height: 100%;
 		object-fit: cover;
 		object-position: center;
-		overflow: hidden;
+				overflow: hidden;
+		filter: grayscale(0.1);
 												
 	}
 

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -131,7 +131,7 @@
 		object-fit: cover;
 		object-position: center;
 		overflow: hidden;
-						filter: grayscale(1) sepia(0.5) hue-rotate(250deg) saturate(1.0);
+								filter: grayscale(0.7) sepia(0.5) hue-rotate(250deg) saturate(1.0);
 	}
 
 		@media (min-width: 1024px) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -122,13 +122,13 @@
 		height: 85vh;
 	}
 
-			.image-container img,
+				.image-container img,
 	.image-container :global(img) {
 		display: block;
 		border-radius: 1.5rem;
 		width: 100%;
 		height: 100%;
-		object-fit: contain;
+		object-fit: cover;
 		object-position: center;
 		overflow: hidden;
 	}

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -138,8 +138,7 @@
 			text-align: center;
 		}
 
-				.content {
-			flex-direction: {flexDirection};
+						.content {
 			gap: 3em;
 		}
 

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -121,21 +121,21 @@
 		min-height: 300px;
 	}
 
-			@media (max-width: 1023px) {
+				@media (max-width: 1023px) {
 		.image-container {
-			margin-left: calc(-50vw + 50%) !important;
-			margin-right: calc(-50vw + 50%) !important;
-			width: 100vw !important;
-			max-width: none !important;
+			position: relative;
+			overflow: visible;
 		}
-	}
 
-	:global(.image-container) {
-		@media (max-width: 1023px) {
-			margin-left: calc(-50vw + 50%) !important;
-			margin-right: calc(-50vw + 50%) !important;
+		.image-container img,
+		.image-container :global(img) {
+			position: absolute;
+			left: 50%;
+			transform: translateX(-50%);
 			width: 100vw !important;
-			max-width: none !important;
+			max-width: 100vw !important;
+			margin-left: 0 !important;
+			margin-right: 0 !important;
 		}
 	}
 

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -83,12 +83,12 @@
 		color: inherit;
 	}
 
-		.content {
+			.content {
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
 		align-items: flex-start;
-		gap: 5em;
+		gap: 2em;
 	}
 
 	.text {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -134,13 +134,14 @@
 												
 	}
 
-			@media (min-width: 1024px) {
+				@media (min-width: 1024px) {
 		h2 {
 			text-align: center;
 		}
 
 		.content {
 			gap: 3em;
+			flex-direction: var(--flex-direction, row-reverse) !important;
 		}
 
 		.image-container {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -121,23 +121,7 @@
 		min-height: 300px;
 	}
 
-				@media (max-width: 1023px) {
-		.image-container {
-			position: relative;
-			overflow: visible;
-		}
-
-		.image-container img,
-		.image-container :global(img) {
-			position: absolute;
-			left: 50%;
-			transform: translateX(-50%);
-			width: 100vw !important;
-			max-width: 100vw !important;
-			margin-left: 0 !important;
-			margin-right: 0 !important;
-		}
-	}
+				
 
 					.image-container img,
 	.image-container :global(img) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -134,13 +134,20 @@
 												
 	}
 
-		@media (min-width: 1024px) {
+			@media (min-width: 1024px) {
 		h2 {
 			text-align: center;
 		}
 
-						.content {
+		.content {
 			gap: 3em;
+		}
+
+		.image-container {
+			position: sticky;
+			top: 7.5vh;
+			height: 85vh;
+			max-width: 50%;
 		}
 
 				.image-container {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -131,7 +131,7 @@
 		object-fit: cover;
 		object-position: center;
 		overflow: hidden;
-				filter: grayscale(1) sepia(0.5) hue-rotate(250deg) saturate(0.7);
+						filter: grayscale(1) sepia(0.5) hue-rotate(250deg) saturate(1.0);
 	}
 
 		@media (min-width: 1024px) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -114,11 +114,19 @@
 		margin-top: 3em;
 	}
 
-		.image-container {
+			.image-container {
 		margin-right: auto;
 		margin-left: auto;
 		height: 50vh;
 		min-height: 300px;
+	}
+
+	@media (max-width: 1023px) {
+		.image-container {
+			margin-left: calc(-37.5vw + 37.5%);
+			margin-right: calc(-37.5vw + 37.5%);
+			width: 100vw;
+		}
 	}
 
 					.image-container img,

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -50,7 +50,7 @@
 	<h2 bind:this={heading} style="color: {accent}">
 		<slot name="heading" />
 	</h2>
-	<div class="content" style="flex-direction: {flexDirection}">
+		<div class="content" style:flex-direction={flexDirection}>
 		<div class="text" bind:this={text}>
 			<slot name="text" style="color: {accent}" />
 			<div class="button-container">

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -83,9 +83,9 @@
 		color: inherit;
 	}
 
-	.content {
+		.content {
 		display: flex;
-		flex-direction: column !important;
+		flex-direction: column;
 		justify-content: space-between;
 		align-items: flex-start;
 		gap: 5em;

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -69,10 +69,16 @@
 </div>
 
 <style>
-			.container {
+				.container {
 		margin-right: auto;
 		margin-left: auto;
 		width: 75%;
+	}
+
+	@media (max-width: 767px) {
+		.container {
+			width: 90%;
+		}
 	}
 
 	h2 {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -143,8 +143,8 @@
 			gap: 3em;
 		}
 
-		.image-container {
-			max-width: 45%;
+				.image-container {
+			max-width: 50%;
 		}
 	}
 </style>

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -131,7 +131,7 @@
 		object-fit: cover;
 		object-position: center;
 		overflow: hidden;
-												filter: grayscale(0.7) saturate(1.0);
+												
 	}
 
 		@media (min-width: 1024px) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -121,11 +121,12 @@
 		min-height: 300px;
 	}
 
-	@media (max-width: 1023px) {
+		@media (max-width: 1023px) {
 		.image-container {
-			margin-left: calc(-37.5vw + 37.5%);
-			margin-right: calc(-37.5vw + 37.5%);
+			margin-left: calc(-50vw + 50%);
+			margin-right: calc(-50vw + 50%);
 			width: 100vw;
+			max-width: none;
 		}
 	}
 

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -50,7 +50,7 @@
 	<h2 bind:this={heading} style="color: {accent}">
 		<slot name="heading" />
 	</h2>
-		<div class="content" style:flex-direction={flexDirection}>
+			<div class="content" style:flex-direction="column">
 		<div class="text" bind:this={text}>
 			<slot name="text" style="color: {accent}" />
 			<div class="button-container">

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -58,8 +58,12 @@
 			</div>
 		</div>
 
-		<div class="image-container" bind:this={image}>
-			<enhanced:img src={imageSource} alt={imageAlt} />
+				<div class="image-container" bind:this={image}>
+			{#if typeof imageSource === 'string'}
+				<img src={imageSource} alt={imageAlt} />
+			{:else}
+				<enhanced:img src={imageSource} alt={imageAlt} />
+			{/if}
 		</div>
 	</div>
 </div>

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -130,7 +130,7 @@
 		object-position: center;
 	}
 
-	@media (min-width: 1024px) {
+		@media (min-width: 1024px) {
 		h2 {
 			text-align: center;
 		}
@@ -141,7 +141,7 @@
 		}
 
 		.image-container {
-			max-width: 50%;
+			max-width: 45%;
 		}
 	}
 </style>

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -131,7 +131,7 @@
 		object-fit: cover;
 		object-position: center;
 		overflow: hidden;
-										filter: grayscale(0.7) sepia(0.3) hue-rotate(250deg) saturate(1.0);
+												filter: grayscale(0.7) saturate(1.0);
 	}
 
 		@media (min-width: 1024px) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -50,7 +50,7 @@
 	<h2 bind:this={heading} style="color: {accent}">
 		<slot name="heading" />
 	</h2>
-			<div class="content" style:flex-direction="column">
+				<div class="content" style="--flex-direction: {flexDirection}">
 		<div class="text" bind:this={text}>
 			<slot name="text" style="color: {accent}" />
 			<div class="button-container">

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -122,7 +122,8 @@
 		height: 85vh;
 	}
 
-	.image-container img {
+		.image-container img,
+	.image-container :global(img) {
 		border-radius: 1.5rem;
 		width: 100%;
 		height: 100%;

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -131,7 +131,7 @@
 		object-fit: cover;
 		object-position: center;
 		overflow: hidden;
-								filter: grayscale(0.7) sepia(0.5) hue-rotate(250deg) saturate(1.0);
+										filter: grayscale(0.7) sepia(0.3) hue-rotate(250deg) saturate(1.0);
 	}
 
 		@media (min-width: 1024px) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -122,13 +122,15 @@
 		height: 85vh;
 	}
 
-		.image-container img,
+			.image-container img,
 	.image-container :global(img) {
+		display: block;
 		border-radius: 1.5rem;
 		width: 100%;
 		height: 100%;
 		object-fit: contain;
 		object-position: center;
+		overflow: hidden;
 	}
 
 		@media (min-width: 1024px) {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -58,8 +58,8 @@
 			</div>
 		</div>
 
-				<div class="image-container" bind:this={image}>
-			{#if typeof imageSource === 'string'}
+						<div class="image-container" bind:this={image}>
+			{#if typeof imageSource === 'string' && (imageSource.startsWith('http') || imageSource.startsWith('//'))}
 				<img src={imageSource} alt={imageAlt} />
 			{:else}
 				<enhanced:img src={imageSource} alt={imageAlt} />

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -69,17 +69,10 @@
 </div>
 
 <style>
-		.container {
+			.container {
 		margin-right: auto;
 		margin-left: auto;
 		width: 75%;
-	}
-
-	@media (max-width: 1023px) {
-		.container {
-			width: 100%;
-			padding: 0;
-		}
 	}
 
 	h2 {

--- a/src/lib/partials/subpage-content.svelte
+++ b/src/lib/partials/subpage-content.svelte
@@ -138,8 +138,8 @@
 			text-align: center;
 		}
 
-		.content {
-			flex-direction: row !important;
+				.content {
+			flex-direction: {flexDirection};
 			gap: 3em;
 		}
 

--- a/src/lib/subpages/about.svelte
+++ b/src/lib/subpages/about.svelte
@@ -3,7 +3,7 @@
 	import About1 from '../../cms/text/about/about1.svelte';
 	import About2 from '../../cms/text/about/about2.svelte';
 	import About3 from '../../cms/text/about/about3.svelte';
-	import AuthorPhoto from '../../cms/images/about/author-photo.jpg?enhanced';
+		const AuthorPhoto = 'https://cdn.builder.io/api/v1/image/assets%2F7055d8d0cc284adcbfeafeb0f4b74e06%2Fb073f806fad94af9be01b13f53ce53b3?format=webp&width=800';
 	import Mirror from '../../cms/images/about/mirror.jpeg?enhanced';
 	import Owl from '../../cms/images/about/owl.png?enhanced';
 	import Socials from '$lib/icons/socials.svelte';

--- a/src/lib/subpages/about.svelte
+++ b/src/lib/subpages/about.svelte
@@ -61,7 +61,6 @@
 <div class="spacer"></div>
 
 <SubpageContent
-	flexDirection="row"
 	{accent}
 	imageSource={AuthorPhoto}
 	imageAlt="Alice Alexandra Moore"

--- a/src/lib/subpages/about.svelte
+++ b/src/lib/subpages/about.svelte
@@ -61,6 +61,7 @@
 <div class="spacer"></div>
 
 <SubpageContent
+	flexDirection="row"
 	{accent}
 	imageSource={AuthorPhoto}
 	imageAlt="Alice Alexandra Moore"

--- a/src/lib/subpages/landing-page.svelte
+++ b/src/lib/subpages/landing-page.svelte
@@ -160,8 +160,15 @@
 		}
 	}
 
-	.image-wrapper.no-padding {
+		.image-wrapper.no-padding {
+		margin-left: -1.25rem;
 		margin-right: -1.25rem;
+	}
+
+	@media (min-width: 768px) {
+		.image-wrapper.no-padding {
+			margin-left: 0;
+		}
 	}
 
 	@media (min-width: 1024px) {

--- a/src/lib/subpages/landing-page.svelte
+++ b/src/lib/subpages/landing-page.svelte
@@ -177,8 +177,16 @@
 		}
 	}
 
-	.image-wrapper img {
+		.image-wrapper img {
 		object-fit: contain;
+	}
+
+	@media (max-width: 767px) {
+		.image-wrapper.no-padding img {
+			width: 100vw;
+			margin-left: calc(-50vw + 50%);
+			object-fit: cover;
+		}
 	}
 
 	.slot-image-wrapper {

--- a/src/lib/subpages/landing-page.svelte
+++ b/src/lib/subpages/landing-page.svelte
@@ -181,10 +181,12 @@
 		object-fit: contain;
 	}
 
-	@media (max-width: 767px) {
+		@media (max-width: 767px) {
 		.image-wrapper.no-padding img {
 			width: 100vw;
-			margin-left: calc(-50vw + 50%);
+			position: relative;
+			left: 50%;
+			transform: translateX(-50%);
 			object-fit: cover;
 		}
 	}


### PR DESCRIPTION
Updates to subpage content component and related pages:

- Change flex-direction from inline style to CSS variable
- Add conditional image rendering for external URLs vs enhanced images
- Update container width to 90% on mobile devices
- Reduce content gap from 5em to 2em
- Change image object-fit from contain to cover
- Remove sticky positioning from image container on mobile
- Add grayscale filter to images
- Update flex-direction to use CSS variable with row-reverse default
- Replace enhanced image import with CDN URL for author photo
- Add responsive margin adjustments for image wrappers
- Update mobile image styling with full viewport width

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c228e088501b4a2ea9fbb00a46b750ec/zen-zone)

👀 [Preview Link](https://c228e088501b4a2ea9fbb00a46b750ec-zen-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c228e088501b4a2ea9fbb00a46b750ec</projectId>-->
<!--<branchName>zen-zone</branchName>-->