### PR TITLE
Remove link underlines and enhance hover colors on HFC page

### DIFF
--- a/src/routes/(landing-pages)/studio/hfc/+page.svelte
+++ b/src/routes/(landing-pages)/studio/hfc/+page.svelte
@@ -621,6 +621,11 @@
 		font-size: 1.5rem;
 		text-align: right;
 
+		&:hover {
+			color: #bcbab7;
+			text-decoration: none;
+		}
+
 		@media (min-width: 768px) {
 			font-size: 1.875rem;
 		}


### PR DESCRIPTION
## Purpose

Based on user feedback, this change addresses styling issues on the HFC page where links needed improved hover behavior. The user specifically requested that links should not show underlines on hover, but should have more dramatic color changes to improve visual feedback.

## Code changes

- **Removed text underlines on hover**: Added `text-decoration: none` to `.poem-link:hover` and the right-aligned link styles
- **Enhanced hover color contrast**: Updated hover colors from `#cfcdcb` to `#bcbab7` for poem link headings and applied the same color to right-aligned links
- **Improved background hover effect**: Changed background color from `#efefef` to `#deddda` for better visual contrast

These changes provide more dramatic visual feedback on hover while removing the unwanted underline decoration across all link elements on the HFC page.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c228e088501b4a2ea9fbb00a46b750ec/vortex-verse)

👀 [Preview Link](https://c228e088501b4a2ea9fbb00a46b750ec-vortex-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c228e088501b4a2ea9fbb00a46b750ec</projectId>-->
<!--<branchName>vortex-verse</branchName>-->