### PR TITLE
Cleanup unused CSS selector warnings

### DIFF
--- a/src/lib/subpages/studio/coming-soon.svelte
+++ b/src/lib/subpages/studio/coming-soon.svelte
@@ -1,36 +1,39 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
+
+	let {
+		title,
+		subtitle,
+		summary,
+		text
+	}: {
+		title: Snippet;
+		subtitle: Snippet;
+		summary: Snippet;
+		text: Snippet;
+	} = $props();
 </script>
 
-<div in:fade={{ duration: 500 }} out:fade={{ duration: 500 }}>
-	<h1>
-		<slot name="title" />
-	</h1>
+<div class="coming-soon" in:fade={{ duration: 500 }} out:fade={{ duration: 500 }}>
+	<h1>{@render title()}</h1>
 	<p>
-		<em>
-			<slot name="subtitle" />
-		</em>
+		<em>{@render subtitle()}</em>
 	</p>
 	<hr />
 	<p>
 		<em class="tl-dr">tl;dr</em>
-		<slot name="summary" />
+		{@render summary()}
 	</p>
 	<hr />
-	<div>
-		<slot name="text" />
-	</div>
+	<div class="coming-soon__text">{@render text()}</div>
 	<p>
 		<a href="/studio#works">back.</a>
 	</p>
 </div>
 
 <style>
-	* {
-		color: #e1e1e1;
-	}
-
-	div {
+	.coming-soon {
 		background-color: black;
 		padding: 2.5rem 1rem;
 		height: 100%;
@@ -39,7 +42,7 @@
 		letter-spacing: 0.025em;
 	}
 
-	div * {
+	.coming-soon * {
 		color: inherit;
 	}
 
@@ -68,17 +71,17 @@
 		font-weight: 500;
 	}
 
-	div > div {
+	.coming-soon__text {
 		max-width: 60ch;
 		font-size: 1.25rem;
 		line-height: 1.75rem;
 	}
 
-	div > div * {
+	:global(.coming-soon__text *) {
 		color: inherit;
 	}
 
-	div > div p {
+	:global(.coming-soon__text p) {
 		margin-bottom: 1em;
 	}
 
@@ -95,7 +98,7 @@
 	}
 
 	@media (min-width: 640px) {
-		div {
+		.coming-soon {
 			padding-right: 2.5rem;
 			padding-left: 2.5rem;
 		}
@@ -119,7 +122,7 @@
 	}
 
 	@media (min-width: 1024px) {
-		div > div {
+		.coming-soon__text {
 			font-size: 1.5rem;
 			line-height: 2rem;
 		}

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -278,11 +278,11 @@
 
 		:global(> p:first-of-type::first-letter),
 		:global(> h2 + p::first-letter) {
-			initial-letter: 2;
 			margin-right: 0.5rem;
 			color: var(--blog-heading);
 			font-weight: 300;
 			font-family: 'Spectral', serif;
+			initial-letter: 2;
 		}
 	}
 
@@ -368,8 +368,8 @@
 			color: var(--blog-heading);
 			font-weight: 400;
 			font-size: 2rem;
-			font-family: 'Spectral', serif;
 			line-height: 1.3;
+			font-family: 'Spectral', serif;
 			text-align: center;
 
 			@media (min-width: 768px) {
@@ -396,10 +396,11 @@
 		:global(.notion-container ol),
 		:global(.notion-container ul) {
 			margin-left: 2em;
+		}
 
-			li {
-				color: inherit;
-			}
+		:global(.notion-container ol li),
+		:global(.notion-container ul li) {
+			color: inherit;
 		}
 
 		:global(.notion-container hr) {
@@ -453,7 +454,8 @@
 			}
 		}
 
-		:global(.notion-container p, li) {
+		:global(.notion-container p),
+		:global(.notion-container li) {
 			color: var(--blog-accent);
 		}
 

--- a/src/routes/(landing-pages)/studio/betson/+page.svelte
+++ b/src/routes/(landing-pages)/studio/betson/+page.svelte
@@ -12,18 +12,18 @@
 	/>
 </svelte:head>
 
-<ComingSoon>
-	<svelte:fragment slot="title">betson, ohio</svelte:fragment>
+{#snippet title()}betson, ohio{/snippet}
 
-	<svelte:fragment slot="subtitle">
-		in the backwoods tangled undergrowth dictates creatures & canopies
-	</svelte:fragment>
+{#snippet subtitle()}
+	in the backwoods tangled undergrowth dictates creatures & canopies
+{/snippet}
 
-	<svelte:fragment slot="summary">
-		Interconnected short stories getting published here soon.
-	</svelte:fragment>
+{#snippet summary()}
+	Interconnected short stories getting published here soon.
+{/snippet}
 
-	<svelte:fragment slot="text">
-		<ComingSoonBetson />
-	</svelte:fragment>
-</ComingSoon>
+{#snippet text()}
+	<ComingSoonBetson />
+{/snippet}
+
+<ComingSoon {title} {subtitle} {summary} {text} />

--- a/src/routes/(landing-pages)/studio/jukebox/+page.svelte
+++ b/src/routes/(landing-pages)/studio/jukebox/+page.svelte
@@ -12,16 +12,16 @@
 	/>
 </svelte:head>
 
-<ComingSoon>
-	<svelte:fragment slot="title">jukebox</svelte:fragment>
+{#snippet title()}jukebox{/snippet}
 
-	<svelte:fragment slot="subtitle">attempts at taming the cacophany of noise</svelte:fragment>
+{#snippet subtitle()}attempts at taming the cacophany of noise{/snippet}
 
-	<svelte:fragment slot="summary">
-		I write music. Will be publishing here and to streaming services soon.
-	</svelte:fragment>
+{#snippet summary()}
+	I write music. Will be publishing here and to streaming services soon.
+{/snippet}
 
-	<svelte:fragment slot="text">
-		<ComingSoonJukebox />
-	</svelte:fragment>
-</ComingSoon>
+{#snippet text()}
+	<ComingSoonJukebox />
+{/snippet}
+
+<ComingSoon {title} {subtitle} {summary} {text} />

--- a/src/routes/(landing-pages)/studio/tmi/+page.svelte
+++ b/src/routes/(landing-pages)/studio/tmi/+page.svelte
@@ -12,16 +12,16 @@
 	/>
 </svelte:head>
 
-<ComingSoon>
-	<svelte:fragment slot="title">these makeshift idiotika</svelte:fragment>
+{#snippet title()}these makeshift idiotika{/snippet}
 
-	<svelte:fragment slot="subtitle">
-		a sprawling world of lovers & fiends torn by an ever-tilting landscape
-	</svelte:fragment>
+{#snippet subtitle()}
+	a sprawling world of lovers & fiends torn by an ever-tilting landscape
+{/snippet}
 
-	<svelte:fragment slot="summary">You'll meet some characters very soon.</svelte:fragment>
+{#snippet summary()}You'll meet some characters very soon.{/snippet}
 
-	<svelte:fragment slot="text">
-		<ComingSoonTMI />
-	</svelte:fragment>
-</ComingSoon>
+{#snippet text()}
+	<ComingSoonTMI />
+{/snippet}
+
+<ComingSoon {title} {subtitle} {summary} {text} />


### PR DESCRIPTION
## Summary
- Refactor `ComingSoon` to require Svelte 5 snippet props and update the Studio pages to pass snippets.
- Fix Notion list-item styling selectors so `vite-plugin-svelte` no longer reports unused `li` rules.