### PR TITLE
chore: upgrade globals to 16.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.13.1",
-		"globals": "^15.15.0",
+		"globals": "^16.5.0",
 		"gsap": "^3.14.2",
 		"marked": "^15.0.12",
 		"mdsvex": "^0.12.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^3.13.1
         version: 3.13.1(eslint@9.39.2)(svelte@5.46.0)
       globals:
-        specifier: ^15.15.0
-        version: 15.15.0
+        specifier: ^16.5.0
+        version: 16.5.0
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
@@ -1256,10 +1256,6 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
-
-  globals@15.15.0:
-    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
   globals@16.5.0:
@@ -2906,8 +2902,6 @@ snapshots:
       path-scurry: 2.0.1
 
   globals@14.0.0: {}
-
-  globals@15.15.0: {}
 
   globals@16.5.0: {}
 


### PR DESCRIPTION
Upgrades `globals` from `^15.15.0` to `^16.5.0`.

- Vercel preview: https://alicealexandra-4hdcj8aoj-alice-moores-projects.vercel.app

Resolves alicealexandra.com-e86

Co-Authored-By: Warp <agent@warp.dev>