### PR TITLE
fix: callout text color in dark mode

### DIFF
--- a/src/lib/styles/prose.css
+++ b/src/lib/styles/prose.css
@@ -193,6 +193,7 @@
 	border-radius: 0.5rem;
 	background-color: var(--prose-callout);
 	padding: var(--prose-spacing-lg) var(--prose-spacing-sm) var(--prose-spacing-md);
+	color: var(--prose-text);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- Adds explicit `color: var(--prose-text)` to `.prose div.callout` to ensure callout text is visible in dark mode
- Fixes issue where callout text was invisible due to inheriting a color that matched the dark background

Fixes alicealexandra.com-bi0