### PR TITLE
Fix postcards H2 font in prose content

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -10,7 +10,6 @@
 	padding: 0;
 	color: #1f2937;
 	font-weight: 300;
-	font-family: 'Lato', sans-serif;
 }
 
 h1,
@@ -42,6 +41,7 @@ li {
 body {
 	background-color: #fafafa;
 	overflow-x: hidden;
+	font-family: 'Lato', sans-serif;
 }
 
 img {


### PR DESCRIPTION
Move base font-family from the universal selector to body so nested inline elements inherit heading fonts (fixes postcards modal + detail page prose H2s).