### PR TITLE
ci: add required checks workflow

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,12 +1,12 @@
 {
-  "mcpServers": {
-    "dev3000": {
-      "type": "http",
-      "url": "http://localhost:3684/mcp"
-    },
-    "vercel": {
-      "type": "http",
-      "url": "https://mcp.vercel.com"
-    }
-  }
+	"mcpServers": {
+		"dev3000": {
+			"type": "http",
+			"url": "http://localhost:3684/mcp"
+		},
+		"vercel": {
+			"type": "http",
+			"url": "https://mcp.vercel.com"
+		}
+	}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,148 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Stub content (CI)
+        run: |
+          mkdir -p content/blog content/poems content/postcards content/studio content/career
+
+          cat > content/blog/posts.json <<'EOF'
+          [
+            {
+              "id": "ci-test",
+              "slug": "ci-test",
+              "title": "CI Test Post",
+              "subtitle": "Placeholder",
+              "category": "CI",
+              "publicationDate": "2026-01-01",
+              "formattedPublicationDate": "Jan 1, 2026",
+              "readTime": "1 min",
+              "coverImage": "/images/placeholder.jpg"
+            }
+          ]
+          EOF
+
+          cat > content/blog/ci-test.md <<'EOF'
+          ---
+          title: "CI Test Post"
+          slug: "ci-test"
+          subtitle: "Placeholder"
+          summary: "Placeholder"
+          ogDescription: "Placeholder"
+          category: "CI"
+          publicationDate: "2026-01-01"
+          formattedPublicationDate: "Jan 1, 2026"
+          readTime: "1 min"
+          coverImage: "/images/placeholder.jpg"
+          coverImageCaption: "Placeholder"
+          notionId: "ci-test"
+          ---
+          Hello from CI.
+          EOF
+
+          cat > content/poems/sections.json <<'EOF'
+          [
+            {
+              "id": "ci-section",
+              "name": "CI",
+              "quote": "",
+              "quoteAuthor": "",
+              "act": "",
+              "coverImage": "",
+              "secondaryImage": "",
+              "sequence": 1
+            }
+          ]
+          EOF
+
+          cat > content/poems/ci-test.md <<'EOF'
+          ---
+          title: "CI Poem"
+          section: "CI"
+          sequence: 1
+          notLineated: true
+          ---
+          Hello from CI.
+          EOF
+
+          cat > content/postcards/metadata.json <<'EOF'
+          [
+            {
+              "id": "ci-test",
+              "slug": "ci-test",
+              "title": "CI Postcard",
+              "description": "Placeholder",
+              "lastEditedTime": "2026-01-01"
+            }
+          ]
+          EOF
+
+          cat > content/postcards/ci-test.md <<'EOF'
+          ---
+          title: "CI Postcard"
+          slug: "ci-test"
+          description: "Placeholder"
+          heroImage: ""
+          lastEditedTime: "2026-01-01"
+          notionId: "ci-test"
+          ---
+          Hello from CI.
+          EOF
+
+          cat > content/studio/cards.json <<'EOF'
+          { "data": [] }
+          EOF
+
+          cat > content/studio/illustrations.json <<'EOF'
+          { "data": [] }
+          EOF
+
+          cat > content/career/publications.json <<'EOF'
+          { "data": [] }
+          EOF
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Check
+        run: pnpm check
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,12 @@
 {
-  "mcpServers": {
-    "dev3000": {
-      "type": "http",
-      "url": "http://localhost:3684/mcp"
-    },
-    "vercel": {
-      "type": "http",
-      "url": "https://mcp.vercel.com"
-    }
-  }
+	"mcpServers": {
+		"dev3000": {
+			"type": "http",
+			"url": "http://localhost:3684/mcp"
+		},
+		"vercel": {
+			"type": "http",
+			"url": "https://mcp.vercel.com"
+		}
+	}
 }

--- a/opencode.json
+++ b/opencode.json
@@ -1,15 +1,15 @@
 {
-  "mcp": {
-    "dev3000": {
-      "type": "remote",
-      "url": "http://localhost:3684/mcp",
-      "enabled": true
-    },
-    "vercel": {
-      "type": "remote",
-      "url": "https://mcp.vercel.com",
-      "enabled": true
-    }
-  },
-  "$schema": "https://opencode.ai/config.json"
+	"mcp": {
+		"dev3000": {
+			"type": "remote",
+			"url": "http://localhost:3684/mcp",
+			"enabled": true
+		},
+		"vercel": {
+			"type": "remote",
+			"url": "https://mcp.vercel.com",
+			"enabled": true
+		}
+	},
+	"$schema": "https://opencode.ai/config.json"
 }

--- a/src/lib/components/postcard-modal.svelte
+++ b/src/lib/components/postcard-modal.svelte
@@ -397,8 +397,8 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-		align-items: flex-end;
 		justify-content: center;
+		align-items: flex-end;
 		background: linear-gradient(
 			180deg,
 			rgba(232, 232, 232, 0) 0%,
@@ -420,8 +420,8 @@
 		color: #1a1a1a;
 		font-weight: 500;
 		font-size: 3rem;
-		font-family: 'Spectral', serif;
 		line-height: 1.1;
+		font-family: 'Spectral', serif;
 		letter-spacing: 0.05em;
 		text-shadow:
 			0 0 25px rgba(232, 232, 232, 0.7),
@@ -434,8 +434,8 @@
 		color: #444;
 		font-style: italic;
 		font-size: 1.3rem;
-		font-family: 'Spectral', serif;
 		line-height: 1.4;
+		font-family: 'Spectral', serif;
 		letter-spacing: 0.05em;
 		text-shadow:
 			0 0 20px rgba(232, 232, 232, 0.7),

--- a/src/routes/(landing-pages)/news/+page.svelte
+++ b/src/routes/(landing-pages)/news/+page.svelte
@@ -312,20 +312,20 @@
 	}
 
 	.tab-button {
+		backdrop-filter: blur(8px);
 		transition: all 0.2s ease;
 		cursor: pointer;
 		border: 1px solid rgba(114, 106, 18, 0.25);
 		border-radius: 999px;
 		background: rgba(255, 255, 255, 0.7);
-		backdrop-filter: blur(8px);
 		padding: 0.6rem 1rem;
 		color: #4b460d;
 		font-weight: 500;
 		letter-spacing: 0.01em;
 
 		&:hover {
-			filter: brightness(0.95);
 			transform: translateY(-1px);
+			filter: brightness(0.95);
 			box-shadow: 0 4px 12px rgba(114, 106, 18, 0.08);
 		}
 	}
@@ -386,11 +386,11 @@
 		display: grid;
 		grid-template-columns: 140px 1fr;
 		gap: 1.25rem;
+		transition: all 0.2s ease;
 		border: 1px solid rgba(114, 106, 18, 0.12);
 		border-radius: 16px;
 		background: rgba(255, 255, 255, 0.6);
 		padding: 1.25rem;
-		transition: all 0.2s ease;
 	}
 
 	.entry--studio {
@@ -576,13 +576,13 @@
 
 	.coming-soon {
 		margin: 2rem 0;
-		padding: 2rem;
 		border-radius: 12px;
 		background: rgba(255, 255, 255, 0.3);
+		padding: 2rem;
 		color: rgba(75, 70, 13, 0.75);
+		font-style: italic;
 		line-height: 1.6;
 		text-align: center;
-		font-style: italic;
 	}
 
 	.changelog-content {

--- a/src/routes/(landing-pages)/studio/postcards/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/studio/postcards/[slug]/+page.svelte
@@ -37,7 +37,6 @@
 
 <main>
 	{#if postcard}
-
 		<article class="postcard-content">
 			{#if htmlContent}
 				<div class="prose">
@@ -86,8 +85,8 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-		align-items: flex-end;
 		justify-content: center;
+		align-items: flex-end;
 		background: linear-gradient(
 			180deg,
 			rgba(232, 232, 232, 0) 0%,
@@ -109,8 +108,8 @@
 		color: #1a1a1a;
 		font-weight: 500;
 		font-size: 4.4rem;
-		font-family: 'Spectral', serif;
 		line-height: 1.1;
+		font-family: 'Spectral', serif;
 		letter-spacing: 0.05em;
 		text-shadow:
 			0 0 25px rgba(232, 232, 232, 0.7),
@@ -123,8 +122,8 @@
 		color: #444;
 		font-style: italic;
 		font-size: 1.75rem;
-		font-family: 'Spectral', serif;
 		line-height: 1.4;
+		font-family: 'Spectral', serif;
 		letter-spacing: 0.05em;
 		text-shadow:
 			0 0 20px rgba(232, 232, 232, 0.7),

--- a/src/routes/api/revalidate/+server.ts
+++ b/src/routes/api/revalidate/+server.ts
@@ -29,7 +29,7 @@ export const POST: RequestHandler = async ({ request, url, fetch: serverFetch })
 			throw error(403, `Route '${route}' is not allowed for revalidation`);
 		}
 
-		const bypassToken = env.BYPASS_TOKEN;
+		const bypassToken = env['BYPASS_TOKEN'];
 		if (!bypassToken) {
 			throw error(500, 'Missing required BYPASS_TOKEN environment variable');
 		}


### PR DESCRIPTION
## Summary
- Add GitHub Actions `CI` workflow with a `ci` job that runs `pnpm lint`, `pnpm check`, `pnpm test`, and `pnpm build`.
- Stub minimal `content/` files in CI so the build can prerender without needing the private content repo.

## Notes
- This keeps Vercel as the source of truth for real content builds, while CI gates code quality and build health.