### PR TITLE
Rollup: bot/integration -> main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - bot/integration
   push:
     branches:
       - main
+      - bot/integration
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 28 Jan 2026
+
+**Patches**
+
+- Fixed blog post layout collapsing at ultrawide breakpoints by removing large `vw`-based horizontal padding. (#87)
+
 ## 28 Dec 2025
 
 **Enhancements**

--- a/src/lib/components/blog-header.svelte
+++ b/src/lib/components/blog-header.svelte
@@ -87,10 +87,6 @@
 		@media (min-width: 1536px) {
 			padding: var(--prose-spacing-xl) var(--prose-spacing-lg);
 		}
-
-		@media (min-width: 1920px) {
-			padding: var(--prose-spacing-xl) 25vw;
-		}
 	}
 
 	/* Breadcrumb */

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -153,10 +153,6 @@
 		@media (min-width: 1536px) {
 			padding: var(--prose-spacing-xl) var(--prose-spacing-lg);
 		}
-
-		@media (min-width: 1920px) {
-			padding: var(--prose-spacing-xl) 25vw;
-		}
 	}
 
 	/* Styles for constraining non-prose sections */


### PR DESCRIPTION
Fixes #87.

Includes changes merged to `bot/integration` since the last rollup:
- #88 Fix blog layout on ultrawide screens (remove >=1920px `25vw` padding on blog header/container)
- Ensure required `ci` check runs for PRs targeting `bot/integration`

Test:
- `pnpm install`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- (optional) `pnpm dev` and confirm `/blog/<slug>` is readable at >=1920px width in Firefox