### PR TITLE
Remove explore button on career page

### DIFF
--- a/src/routes/(landing-pages)/career/+page.svelte
+++ b/src/routes/(landing-pages)/career/+page.svelte
@@ -21,8 +21,7 @@
                 from both my professional life and my wonky experiments."
 		src={Rabbit}
 		alt="A painting of a rabbit coming out of a hat."
-	>
-	</LandingPage>
+	></LandingPage>
 	<Career />
 </div>
 

--- a/src/routes/(landing-pages)/career/+page.svelte
+++ b/src/routes/(landing-pages)/career/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	import LinkButton from '$lib/components/ui/link-button.svelte';
 	import Career from './career.svelte';
 	import LandingPage from '$lib/components/landing-page.svelte';
 
@@ -23,7 +22,6 @@
 		src={Rabbit}
 		alt="A painting of a rabbit coming out of a hat."
 	>
-		<LinkButton slot="button" href="#content" size="lg">Explore.</LinkButton>
 	</LandingPage>
 	<Career />
 </div>


### PR DESCRIPTION
### Summary
This PR removes the non-functional "explore" button from the `/career` landing page.

### Problem
The "explore" button on the `/career` page did not perform any action when clicked, creating confusion and a suboptimal user experience.

### Solution
Removed the unused button component from the career landing page to clean up the interface.

### Key Changes
* Removed the `<LinkButton>` containing the "Explore." text from `src/routes/(landing-pages)/career/+page.svelte`.
* Cleaned up the unused `LinkButton` import in the same file.

---

<a href="https://builder.io/app/projects/4bf0f5dccbe548cbbe70edee08807ec5/royal-registry-oxzcpr3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://4bf0f5dccbe548cbbe70edee08807ec5-royal-registry-oxzcpr3f_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 136`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4bf0f5dccbe548cbbe70edee08807ec5</projectId>-->
<!--<branchName>royal-registry-oxzcpr3f</branchName>-->