### PR TITLE
Fix blog formatting for therapy satire post

### DIFF
--- a/src/lib/styles/prose.css
+++ b/src/lib/styles/prose.css
@@ -20,13 +20,13 @@
 }
 
 /* Drop caps */
-.prose > p:first-of-type,
+.prose > p:first-child,
 .prose > h2 + p,
 .prose > hr + p {
 	overflow: hidden;
 }
 
-.prose > p:first-of-type::first-letter,
+.prose > p:first-child::first-letter,
 .prose > h2 + p::first-letter,
 .prose > hr + p::first-letter {
 	margin-right: 0.5rem;

--- a/src/lib/styles/prose.css
+++ b/src/lib/styles/prose.css
@@ -120,7 +120,7 @@
 }
 
 .prose > h2:first-child {
-	margin-top: 1.75em;
+	margin-top: 0.875em;
 }
 
 @media (min-width: 768px) {

--- a/src/lib/styles/prose.css
+++ b/src/lib/styles/prose.css
@@ -101,6 +101,15 @@
 	object-fit: contain;
 }
 
+.prose .session-interlude-video {
+	display: block;
+	margin: 2em 0;
+	border-radius: 1.5rem;
+	width: 100%;
+	height: auto;
+	object-fit: contain;
+}
+
 @media (min-width: 1024px) {
 	.prose img {
 		object-position: left;

--- a/src/lib/styles/prose.css
+++ b/src/lib/styles/prose.css
@@ -20,15 +20,15 @@
 }
 
 /* Drop caps */
-.prose > p:first-child,
-.prose > h2 + p,
-.prose > hr + p {
+.prose > p:first-child:not(.dropcap-opt-out),
+.prose > h2 + p:not(.dropcap-opt-out),
+.prose > hr + p:not(.dropcap-opt-out) {
 	overflow: hidden;
 }
 
-.prose > p:first-child::first-letter,
-.prose > h2 + p::first-letter,
-.prose > hr + p::first-letter {
+.prose > p:first-child:not(.dropcap-opt-out)::first-letter,
+.prose > h2 + p:not(.dropcap-opt-out)::first-letter,
+.prose > hr + p:not(.dropcap-opt-out)::first-letter {
 	margin-right: 0.5rem;
 	color: var(--color-content-heading);
 	font-weight: 300;

--- a/src/lib/styles/prose.css
+++ b/src/lib/styles/prose.css
@@ -119,6 +119,10 @@
 	text-align: center;
 }
 
+.prose > h2:first-child {
+	margin-top: 1.75em;
+}
+
 @media (min-width: 768px) {
 	.prose h2 {
 		font-size: 2.5rem;

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -40,6 +40,7 @@
 		}
 
 		videos.forEach((video) => {
+			video.controls = false;
 			video.muted = true;
 			video.loop = true;
 			video.playsInline = true;

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -26,6 +26,47 @@
 		}
 	};
 
+	const setupInlineVideos = () => {
+		if (!context || typeof IntersectionObserver === 'undefined') {
+			return () => {};
+		}
+
+		const videos = Array.from(context.querySelectorAll<HTMLVideoElement>('.session-interlude-video'));
+
+		if (!videos.length) {
+			return () => {};
+		}
+
+		videos.forEach((video) => {
+			video.muted = true;
+			video.loop = true;
+			video.playsInline = true;
+		});
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					const video = entry.target as HTMLVideoElement;
+
+					if (entry.isIntersecting) {
+						void video.play().catch(() => {});
+						return;
+					}
+
+					video.pause();
+				});
+			},
+			{ threshold: 0.5 }
+		);
+
+		videos.forEach((video) => observer.observe(video));
+
+		return () => {
+			observer.disconnect();
+			videos.forEach((video) => video.pause());
+		};
+	};
+
 	export let data: { post: BlogPost };
 
 	const { post } = data;
@@ -46,7 +87,16 @@
 	const htmlContent = marked.parse(post.content);
 
 	onMount(() => {
-		runBlogHelpers();
+		let cleanup = () => {};
+
+		void (async () => {
+			await runBlogHelpers();
+			cleanup = setupInlineVideos();
+		})();
+
+		return () => {
+			cleanup();
+		};
 	});
 </script>
 

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -31,7 +31,9 @@
 			return () => {};
 		}
 
-		const videos = Array.from(context.querySelectorAll<HTMLVideoElement>('.session-interlude-video'));
+		const videos = Array.from(
+			context.querySelectorAll<HTMLVideoElement>('.session-interlude-video')
+		);
 
 		if (!videos.length) {
 			return () => {};


### PR DESCRIPTION
### Summary
Fixes CSS formatting conflicts for the Claude therapy satire blog post and adds support for autoplay inline videos between sections. Introduces an opt-out mechanism for drop caps and improves heading spacing when a post starts with an `h2`.

### Problem
The existing CSS drop cap and heading styles didn't play nicely with the structure of the therapy satire post, which uses `h2`/`h3` section headers and SOAP-note-style formatting. There was no way for individual posts to opt out of drop caps, and the large decorative drop cap "H" would incorrectly fire when an `h2` appeared first in a post. Additionally, the post needed interlude videos between sessions that autoplay on scroll and loop silently.

### Solution
Rather than rewriting the post to work around the CSS, the styles were updated to support a `dropcap-opt-out` class that any paragraph can use to suppress the drop cap. A top-margin reduction was added for `h2` elements that appear as the first child in a prose block. Inline video support was added via an `IntersectionObserver` that autoplays and pauses `.session-interlude-video` elements based on viewport visibility.

### Key Changes
- **Drop cap opt-out**: Updated `.prose` drop cap selectors to respect a `dropcap-opt-out` class, allowing specific paragraphs (e.g., those following an `h3`) to skip the decorative first-letter styling
- **First-child `h2` spacing**: Added `.prose > h2:first-child` rule to reduce top margin by ~75% when a post opens with an `h2`, preventing excessive whitespace
- **Inline video styles**: Added `.session-interlude-video` CSS class with block display, rounded corners, and full-width sizing for interlude clips embedded in blog content
- **Autoplay on scroll**: Implemented `setupInlineVideos()` in the blog page component using `IntersectionObserver` (50% threshold) to play/pause videos as they enter/leave the viewport — videos are muted, looping, controls-hidden, and inline by default
- **Lifecycle cleanup**: Properly disconnects the observer and pauses all videos on component unmount

---

<a href="https://builder.io/app/projects/4bf0f5dccbe548cbbe70edee08807ec5/hero-node-tj9rwlcv"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://4bf0f5dccbe548cbbe70edee08807ec5-hero-node-tj9rwlcv_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 141`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4bf0f5dccbe548cbbe70edee08807ec5</projectId>-->
<!--<branchName>hero-node-tj9rwlcv</branchName>-->