### PR TITLE
Add inline visual editor for blog content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,17 @@ R2_ACCESS_KEY_ID=your_r2_access_key_id
 R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
 R2_PUBLIC_BASE_URL=https://images.alicealexandra.com
 R2_KEY_PREFIX=
+
+# Owner editor authentication
+OWNER_SESSION_SECRET=replace_with_a_long_random_secret
+OWNER_GITHUB_LOGIN=your_github_username
+# OWNER_GITHUB_ID=12345678
+GITHUB_OAUTH_CLIENT_ID=your_github_oauth_app_client_id
+GITHUB_OAUTH_CLIENT_SECRET=your_github_oauth_app_client_secret
+
+# Content publishing
+CONTENT_REPO_OWNER=your_github_org_or_username
+CONTENT_REPO_NAME=teenylilcontent
+CONTENT_REPO_BRANCH=main
+GITHUB_WRITE_TOKEN=your_repo_write_token
+VERCEL_DEPLOY_HOOK_URL=https://api.vercel.com/v1/integrations/deploy/...

--- a/.env.example
+++ b/.env.example
@@ -26,4 +26,3 @@ CONTENT_REPO_OWNER=your_github_org_or_username
 CONTENT_REPO_NAME=teenylilcontent
 CONTENT_REPO_BRANCH=main
 GITHUB_WRITE_TOKEN=your_repo_write_token
-VERCEL_DEPLOY_HOOK_URL=https://api.vercel.com/v1/integrations/deploy/...

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,9 +1,14 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
+import type { OwnerSession } from '$lib/server/owner-session';
+
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			owner: OwnerSession | null;
+			isOwner: boolean;
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,10 @@
+import type { Handle } from '@sveltejs/kit';
+import { readOwnerSession } from '$lib/server/owner-session';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const owner = readOwnerSession(event.cookies);
+	event.locals.owner = owner;
+	event.locals.isOwner = Boolean(owner);
+
+	return resolve(event);
+};

--- a/src/lib/blog/render-markdown.ts
+++ b/src/lib/blog/render-markdown.ts
@@ -1,0 +1,38 @@
+import { Marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import hljs from 'highlight.js/lib/core';
+import typescript from 'highlight.js/lib/languages/typescript';
+import javascript from 'highlight.js/lib/languages/javascript';
+import plaintext from 'highlight.js/lib/languages/plaintext';
+
+let languagesRegistered = false;
+
+function ensureHighlightLanguages() {
+	if (languagesRegistered) {
+		return;
+	}
+
+	hljs.registerLanguage('typescript', typescript);
+	hljs.registerLanguage('javascript', javascript);
+	hljs.registerLanguage('plaintext', plaintext);
+	languagesRegistered = true;
+}
+
+function createRenderer() {
+	ensureHighlightLanguages();
+
+	return new Marked(
+		markedHighlight({
+			emptyLangClass: 'hljs',
+			langPrefix: 'hljs language-',
+			highlight(code, lang) {
+				const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+				return hljs.highlight(code, { language }).value;
+			}
+		})
+	);
+}
+
+export function renderBlogMarkdown(markdown: string): string {
+	return createRenderer().parse(markdown) as string;
+}

--- a/src/lib/components/blog-markdown-content.svelte
+++ b/src/lib/components/blog-markdown-content.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import '$lib/styles/prose.css';
+	import { afterUpdate, onMount, tick } from 'svelte';
+	import { createTOC, subAndSuper } from '$lib/notion/utils/blog-helpers';
+	import { renderBlogMarkdown } from '$lib/blog/render-markdown';
+
+	export let markdown = '';
+	export let contentClass = 'prose';
+	export let emptyText = 'No content available.';
+
+	let context: HTMLElement;
+	let cleanupInlineVideos = () => {};
+
+	$: htmlContent = renderBlogMarkdown(markdown);
+
+	const setupInlineVideos = () => {
+		if (!context || typeof IntersectionObserver === 'undefined') {
+			return () => {};
+		}
+
+		const videos = Array.from(
+			context.querySelectorAll<HTMLVideoElement>('.session-interlude-video')
+		);
+
+		if (!videos.length) {
+			return () => {};
+		}
+
+		videos.forEach((video) => {
+			video.controls = false;
+			video.muted = true;
+			video.loop = true;
+			video.playsInline = true;
+		});
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					const video = entry.target as HTMLVideoElement;
+
+					if (entry.isIntersecting) {
+						void video.play().catch(() => {});
+						return;
+					}
+
+					video.pause();
+				});
+			},
+			{ threshold: 0.5 }
+		);
+
+		videos.forEach((video) => observer.observe(video));
+
+		return () => {
+			observer.disconnect();
+			videos.forEach((video) => video.pause());
+		};
+	};
+
+	const refreshEnhancements = async () => {
+		await tick();
+		cleanupInlineVideos();
+
+		if (!context) {
+			return;
+		}
+
+		subAndSuper(context);
+		createTOC();
+		cleanupInlineVideos = setupInlineVideos();
+	};
+
+	onMount(() => {
+		void refreshEnhancements();
+
+		return () => {
+			cleanupInlineVideos();
+		};
+	});
+
+	afterUpdate(() => {
+		void refreshEnhancements();
+	});
+</script>
+
+{#if htmlContent}
+	<div class={contentClass} bind:this={context}>
+		{@html htmlContent}
+	</div>
+{:else}
+	<p>{emptyText}</p>
+{/if}

--- a/src/lib/content/blog-source.ts
+++ b/src/lib/content/blog-source.ts
@@ -1,0 +1,155 @@
+import fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createHash } from 'node:crypto';
+
+const BLOG_CONTENT_PATH = path.join(process.cwd(), 'content', 'blog');
+const BLOG_READING_SPEED_WORDS_PER_MINUTE = 225;
+
+const BLOG_FRONTMATTER_FIELDS = [
+	'title',
+	'slug',
+	'subtitle',
+	'summary',
+	'ogDescription',
+	'category',
+	'publicationDate',
+	'formattedPublicationDate',
+	'coverImage',
+	'coverImageCaption',
+	'notionId'
+] as const;
+
+export interface BlogFrontmatter {
+	title: string;
+	slug: string;
+	subtitle: string;
+	summary: string;
+	ogDescription: string;
+	category: string;
+	publicationDate: string;
+	formattedPublicationDate: string;
+	coverImage: string;
+	coverImageCaption: string;
+	notionId: string;
+}
+
+export interface EditableBlogDocument {
+	frontmatter: BlogFrontmatter;
+	content: string;
+	rawSource: string;
+	checksum: string;
+}
+
+export function isValidBlogSlug(slug: string): boolean {
+	return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug);
+}
+
+function createEmptyBlogFrontmatter(): BlogFrontmatter {
+	return {
+		title: '',
+		slug: '',
+		subtitle: '',
+		summary: '',
+		ogDescription: '',
+		category: '',
+		publicationDate: '',
+		formattedPublicationDate: '',
+		coverImage: '',
+		coverImageCaption: '',
+		notionId: ''
+	};
+}
+
+export function normalizeBlogFrontmatter(
+	frontmatter: Partial<BlogFrontmatter>,
+	slug: string
+): BlogFrontmatter {
+	return {
+		...createEmptyBlogFrontmatter(),
+		...frontmatter,
+		slug
+	};
+}
+
+export function parseBlogMarkdown(content: string): { frontmatter: BlogFrontmatter; body: string } {
+	const frontmatterRegex = /^---\n([\s\S]*?)\n---\n?/;
+	const match = content.match(frontmatterRegex);
+
+	if (!match || !match[1]) {
+		throw new Error('No frontmatter found in markdown file');
+	}
+
+	const frontmatterStr = match[1];
+	const body = content.slice(match[0].length);
+	const frontmatter = createEmptyBlogFrontmatter();
+
+	for (const line of frontmatterStr.split('\n')) {
+		const colonIndex = line.indexOf(':');
+		if (colonIndex <= 0) {
+			continue;
+		}
+
+		const key = line.slice(0, colonIndex).trim() as keyof BlogFrontmatter;
+		let value = line.slice(colonIndex + 1).trim();
+
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\'/g, "'");
+		}
+
+		if (key in frontmatter) {
+			frontmatter[key] = value;
+		}
+	}
+
+	return {
+		frontmatter,
+		body: body.trim()
+	};
+}
+
+function escapeYamlString(value: string): string {
+	return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export function serializeBlogMarkdown(frontmatter: BlogFrontmatter, body: string): string {
+	const normalizedBody = body.trim();
+	const frontmatterLines = BLOG_FRONTMATTER_FIELDS.map(
+		(field) => `${field}: "${escapeYamlString(frontmatter[field] ?? '')}"`
+	);
+
+	return `---\n${frontmatterLines.join('\n')}\n---\n\n${normalizedBody}\n`;
+}
+
+export function calculateBlogReadTimeFromContent(content: string): string {
+	const wordCount = content.match(/\b[\w'-]+\b/g)?.length ?? 0;
+	const minutes = Math.max(1, Math.ceil(wordCount / BLOG_READING_SPEED_WORDS_PER_MINUTE));
+	return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+}
+
+export function createBlogSourceChecksum(source: string): string {
+	return createHash('sha1').update(source).digest('hex');
+}
+
+export async function loadRawBlogMarkdownBySlug(slug: string): Promise<EditableBlogDocument | null> {
+	if (!isValidBlogSlug(slug)) {
+		return null;
+	}
+
+	try {
+		const filePath = path.join(BLOG_CONTENT_PATH, `${slug}.md`);
+		const rawSource = await fs.readFile(filePath, 'utf-8');
+		const { frontmatter, body } = parseBlogMarkdown(rawSource);
+
+		return {
+			frontmatter,
+			content: body,
+			rawSource,
+			checksum: createBlogSourceChecksum(rawSource)
+		};
+	} catch {
+		return null;
+	}
+}

--- a/src/lib/content/blog.ts
+++ b/src/lib/content/blog.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { calculateBlogReadTimeFromContent, parseBlogMarkdown } from '$lib/content/blog-source';
 
 const CONTENT_PATH = path.join(process.cwd(), 'content', 'blog');
-const BLOG_READING_SPEED_WORDS_PER_MINUTE = 225;
 
 export interface BlogPostMeta {
 	id: string;
@@ -24,63 +24,6 @@ export interface BlogPost extends BlogPostMeta {
 	content: string;
 }
 
-interface BlogFrontmatter {
-	title: string;
-	slug: string;
-	subtitle: string;
-	summary: string;
-	ogDescription: string;
-	category: string;
-	publicationDate: string;
-	formattedPublicationDate: string;
-	readTime: string;
-	coverImage: string;
-	coverImageCaption: string;
-	notionId: string;
-}
-
-function parseFrontmatter(content: string): { frontmatter: BlogFrontmatter; body: string } {
-	const frontmatterRegex = /^---\n([\s\S]*?)\n---\n/;
-	const match = content.match(frontmatterRegex);
-
-	if (!match || !match[1]) {
-		throw new Error('No frontmatter found in markdown file');
-	}
-
-	const frontmatterStr: string = match[1];
-	const body = content.slice(match[0].length);
-
-	const frontmatter: Record<string, any> = {};
-	for (const line of frontmatterStr.split('\n')) {
-		const colonIndex = line.indexOf(':');
-		if (colonIndex > 0) {
-			const key = line.slice(0, colonIndex).trim();
-			let value: any = line.slice(colonIndex + 1).trim();
-
-			if (
-				(value.startsWith('"') && value.endsWith('"')) ||
-				(value.startsWith("'") && value.endsWith("'"))
-			) {
-				value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\'/g, "'");
-			} else if (value === 'true') value = true;
-			else if (value === 'false') value = false;
-
-			frontmatter[key] = value;
-		}
-	}
-
-	return {
-		frontmatter: frontmatter as BlogFrontmatter,
-		body: body.trim()
-	};
-}
-
-function calculateReadTimeFromContent(content: string): string {
-	const wordCount = content.match(/\b[\w'-]+\b/g)?.length ?? 0;
-	const minutes = Math.max(1, Math.ceil(wordCount / BLOG_READING_SPEED_WORDS_PER_MINUTE));
-	return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
-}
-
 export async function loadPostsMeta(): Promise<BlogPostMeta[]> {
 	const postsPath = path.join(CONTENT_PATH, 'posts.json');
 	const content = await fs.readFile(postsPath, 'utf-8');
@@ -92,7 +35,7 @@ export async function loadPostBySlug(slug: string): Promise<BlogPost | null> {
 	try {
 		const filePath = path.join(CONTENT_PATH, `${slug}.md`);
 		const fileContent = await fs.readFile(filePath, 'utf-8');
-		const { frontmatter, body } = parseFrontmatter(fileContent);
+		const { frontmatter, body } = parseBlogMarkdown(fileContent);
 
 		return {
 			id: frontmatter.notionId,
@@ -104,7 +47,7 @@ export async function loadPostBySlug(slug: string): Promise<BlogPost | null> {
 			category: frontmatter.category,
 			publicationDate: frontmatter.publicationDate,
 			formattedPublicationDate: frontmatter.formattedPublicationDate,
-			readTime: calculateReadTimeFromContent(body),
+			readTime: calculateBlogReadTimeFromContent(body),
 			coverImage: frontmatter.coverImage,
 			coverImageCaption: frontmatter.coverImageCaption,
 			notionId: frontmatter.notionId,
@@ -124,7 +67,7 @@ export async function loadAllPosts(): Promise<BlogPost[]> {
 	for (const file of mdFiles) {
 		const filePath = path.join(CONTENT_PATH, file);
 		const fileContent = await fs.readFile(filePath, 'utf-8');
-		const { frontmatter, body } = parseFrontmatter(fileContent);
+		const { frontmatter, body } = parseBlogMarkdown(fileContent);
 
 		posts.push({
 			id: frontmatter.notionId,
@@ -136,7 +79,7 @@ export async function loadAllPosts(): Promise<BlogPost[]> {
 			category: frontmatter.category,
 			publicationDate: frontmatter.publicationDate,
 			formattedPublicationDate: frontmatter.formattedPublicationDate,
-			readTime: calculateReadTimeFromContent(body),
+			readTime: calculateBlogReadTimeFromContent(body),
 			coverImage: frontmatter.coverImage,
 			coverImageCaption: frontmatter.coverImageCaption,
 			notionId: frontmatter.notionId,

--- a/src/lib/server/blog-publishing.ts
+++ b/src/lib/server/blog-publishing.ts
@@ -22,7 +22,6 @@ interface ContentRepoConfig {
 
 interface PublishStatus {
 	contentRepoConfigured: boolean;
-	deployHookConfigured: boolean;
 }
 
 interface SaveBlogPostInput {
@@ -35,7 +34,6 @@ interface SaveBlogPostInput {
 export interface SaveBlogPostResult {
 	commitSha: string;
 	commitUrl: string;
-	deployTriggered: boolean;
 	checksum: string;
 	readTime: string;
 }
@@ -72,8 +70,7 @@ export function getBlogPublishStatus(): PublishStatus {
 			env['CONTENT_REPO_OWNER']?.trim() &&
 			env['CONTENT_REPO_NAME']?.trim() &&
 			(env['GITHUB_WRITE_TOKEN']?.trim() || env['GITHUB_TOKEN']?.trim())
-		),
-		deployHookConfigured: Boolean(env['VERCEL_DEPLOY_HOOK_URL']?.trim())
+		)
 	};
 }
 
@@ -227,20 +224,6 @@ async function createCommit(
 	return nextCommit;
 }
 
-async function triggerVercelDeploy(): Promise<boolean> {
-	const deployHookUrl = env['VERCEL_DEPLOY_HOOK_URL']?.trim();
-	if (!deployHookUrl) {
-		return false;
-	}
-
-	const response = await fetch(deployHookUrl, { method: 'POST' });
-	if (!response.ok) {
-		throw new PublishError(`Vercel deploy hook failed with status ${response.status}.`, 502);
-	}
-
-	return true;
-}
-
 function validateBlogDocument(input: SaveBlogPostInput): {
 	frontmatter: BlogFrontmatter;
 	source: string;
@@ -317,12 +300,9 @@ export async function saveBlogPost(input: SaveBlogPostInput): Promise<SaveBlogPo
 		`Edit blog post: ${frontmatter.slug}`
 	);
 
-	const deployTriggered = await triggerVercelDeploy();
-
 	return {
 		commitSha: commit.sha,
 		commitUrl: commit.html_url,
-		deployTriggered,
 		checksum: createBlogSourceChecksum(source),
 		readTime
 	};

--- a/src/lib/server/blog-publishing.ts
+++ b/src/lib/server/blog-publishing.ts
@@ -1,0 +1,329 @@
+import { env } from '$env/dynamic/private';
+import type { BlogPostMeta } from '$lib/content/blog';
+import {
+	calculateBlogReadTimeFromContent,
+	createBlogSourceChecksum,
+	type BlogFrontmatter,
+	isValidBlogSlug,
+	serializeBlogMarkdown
+} from '$lib/content/blog-source';
+
+interface GitHubContentFile {
+	sha: string;
+	content: string;
+}
+
+interface ContentRepoConfig {
+	owner: string;
+	repo: string;
+	branch: string;
+	token: string;
+}
+
+interface PublishStatus {
+	contentRepoConfigured: boolean;
+	deployHookConfigured: boolean;
+}
+
+interface SaveBlogPostInput {
+	slug: string;
+	frontmatter: BlogFrontmatter;
+	content: string;
+	originalChecksum: string;
+}
+
+export interface SaveBlogPostResult {
+	commitSha: string;
+	commitUrl: string;
+	deployTriggered: boolean;
+	checksum: string;
+	readTime: string;
+}
+
+export class PublishError extends Error {
+	status: number;
+
+	constructor(message: string, status = 500) {
+		super(message);
+		this.name = 'PublishError';
+		this.status = status;
+	}
+}
+
+function getContentRepoConfig(): ContentRepoConfig {
+	const owner = env['CONTENT_REPO_OWNER']?.trim() || '';
+	const repo = env['CONTENT_REPO_NAME']?.trim() || '';
+	const branch = env['CONTENT_REPO_BRANCH']?.trim() || 'main';
+	const token = env['GITHUB_WRITE_TOKEN']?.trim() || env['GITHUB_TOKEN']?.trim() || '';
+
+	if (!owner || !repo || !token) {
+		throw new PublishError(
+			'Content publishing is not configured. Set CONTENT_REPO_OWNER, CONTENT_REPO_NAME, and GITHUB_WRITE_TOKEN.',
+			500
+		);
+	}
+
+	return { owner, repo, branch, token };
+}
+
+export function getBlogPublishStatus(): PublishStatus {
+	return {
+		contentRepoConfigured: Boolean(
+			env['CONTENT_REPO_OWNER']?.trim() &&
+			env['CONTENT_REPO_NAME']?.trim() &&
+			(env['GITHUB_WRITE_TOKEN']?.trim() || env['GITHUB_TOKEN']?.trim())
+		),
+		deployHookConfigured: Boolean(env['VERCEL_DEPLOY_HOOK_URL']?.trim())
+	};
+}
+
+async function githubRequest<T>(
+	config: ContentRepoConfig,
+	path: string,
+	init?: RequestInit
+): Promise<T> {
+	const response = await fetch(`https://api.github.com${path}`, {
+		...init,
+		headers: {
+			Accept: 'application/vnd.github+json',
+			Authorization: `Bearer ${config.token}`,
+			'User-Agent': 'alicealexandra-owner-editor',
+			'Content-Type': 'application/json',
+			...init?.headers
+		}
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new PublishError(
+			`GitHub request failed (${response.status}): ${errorText}`,
+			response.status
+		);
+	}
+
+	return (await response.json()) as T;
+}
+
+function decodeGitHubContent(file: GitHubContentFile): string {
+	return Buffer.from(file.content.replace(/\n/g, ''), 'base64').toString('utf-8');
+}
+
+async function loadGitHubFile(
+	config: ContentRepoConfig,
+	filePath: string
+): Promise<GitHubContentFile> {
+	const encodedPath = filePath
+		.split('/')
+		.map((segment) => encodeURIComponent(segment))
+		.join('/');
+
+	const response = await githubRequest<{ sha: string; content: string }>(
+		config,
+		`/repos/${config.owner}/${config.repo}/contents/${encodedPath}?ref=${encodeURIComponent(config.branch)}`
+	);
+
+	return {
+		sha: response.sha,
+		content: response.content
+	};
+}
+
+function updatePostsIndex(
+	currentPostsJson: string,
+	frontmatter: BlogFrontmatter,
+	content: string
+): string {
+	const parsed = JSON.parse(currentPostsJson) as
+		| { $schema?: string; data?: BlogPostMeta[] }
+		| BlogPostMeta[];
+	const posts = Array.isArray(parsed) ? parsed : (parsed.data ?? []);
+	const nextPost: BlogPostMeta = {
+		id: frontmatter.notionId,
+		slug: frontmatter.slug,
+		title: frontmatter.title,
+		subtitle: frontmatter.subtitle,
+		category: frontmatter.category,
+		publicationDate: frontmatter.publicationDate,
+		formattedPublicationDate: frontmatter.formattedPublicationDate,
+		readTime: calculateBlogReadTimeFromContent(content),
+		coverImage: frontmatter.coverImage
+	};
+
+	const existingIndex = posts.findIndex((post) => post.slug === frontmatter.slug);
+	const nextPosts = [...posts];
+
+	if (existingIndex >= 0) {
+		nextPosts[existingIndex] = nextPost;
+	} else {
+		nextPosts.push(nextPost);
+	}
+
+	nextPosts.sort((left, right) => right.publicationDate.localeCompare(left.publicationDate));
+
+	if (Array.isArray(parsed)) {
+		return `${JSON.stringify(nextPosts, null, 2)}\n`;
+	}
+
+	return `${JSON.stringify({ ...parsed, data: nextPosts }, null, 2)}\n`;
+}
+
+async function createCommit(
+	config: ContentRepoConfig,
+	files: Array<{ path: string; content: string }>,
+	message: string
+) {
+	const headRef = await githubRequest<{ object: { sha: string } }>(
+		config,
+		`/repos/${config.owner}/${config.repo}/git/ref/heads/${encodeURIComponent(config.branch)}`
+	);
+	const headSha = headRef.object.sha;
+	const headCommit = await githubRequest<{ tree: { sha: string } }>(
+		config,
+		`/repos/${config.owner}/${config.repo}/git/commits/${headSha}`
+	);
+
+	const nextTree = await githubRequest<{ sha: string }>(
+		config,
+		`/repos/${config.owner}/${config.repo}/git/trees`,
+		{
+			method: 'POST',
+			body: JSON.stringify({
+				base_tree: headCommit.tree.sha,
+				tree: files.map((file) => ({
+					path: file.path,
+					mode: '100644',
+					type: 'blob',
+					content: file.content
+				}))
+			})
+		}
+	);
+
+	const nextCommit = await githubRequest<{ sha: string; html_url: string }>(
+		config,
+		`/repos/${config.owner}/${config.repo}/git/commits`,
+		{
+			method: 'POST',
+			body: JSON.stringify({
+				message,
+				tree: nextTree.sha,
+				parents: [headSha]
+			})
+		}
+	);
+
+	await githubRequest(
+		config,
+		`/repos/${config.owner}/${config.repo}/git/refs/heads/${encodeURIComponent(config.branch)}`,
+		{
+			method: 'PATCH',
+			body: JSON.stringify({
+				sha: nextCommit.sha,
+				force: false
+			})
+		}
+	);
+
+	return nextCommit;
+}
+
+async function triggerVercelDeploy(): Promise<boolean> {
+	const deployHookUrl = env['VERCEL_DEPLOY_HOOK_URL']?.trim();
+	if (!deployHookUrl) {
+		return false;
+	}
+
+	const response = await fetch(deployHookUrl, { method: 'POST' });
+	if (!response.ok) {
+		throw new PublishError(`Vercel deploy hook failed with status ${response.status}.`, 502);
+	}
+
+	return true;
+}
+
+function validateBlogDocument(input: SaveBlogPostInput): {
+	frontmatter: BlogFrontmatter;
+	source: string;
+} {
+	if (!isValidBlogSlug(input.slug)) {
+		throw new PublishError('Invalid blog slug.', 400);
+	}
+
+	const title = input.frontmatter.title.trim();
+	const publicationDate = input.frontmatter.publicationDate.trim();
+	const formattedPublicationDate = input.frontmatter.formattedPublicationDate.trim();
+	const notionId = input.frontmatter.notionId.trim();
+	const body = input.content.trim();
+
+	if (!title || !publicationDate || !formattedPublicationDate || !notionId || !body) {
+		throw new PublishError(
+			'Title, publication date, formatted publication date, notion ID, and markdown content are required.',
+			400
+		);
+	}
+
+	const frontmatter: BlogFrontmatter = {
+		...input.frontmatter,
+		title,
+		slug: input.slug,
+		subtitle: input.frontmatter.subtitle.trim(),
+		summary: input.frontmatter.summary.trim(),
+		ogDescription: input.frontmatter.ogDescription.trim(),
+		category: input.frontmatter.category.trim(),
+		publicationDate,
+		formattedPublicationDate,
+		coverImage: input.frontmatter.coverImage.trim(),
+		coverImageCaption: input.frontmatter.coverImageCaption.trim(),
+		notionId
+	};
+
+	return {
+		frontmatter,
+		source: serializeBlogMarkdown(frontmatter, body)
+	};
+}
+
+export async function saveBlogPost(input: SaveBlogPostInput): Promise<SaveBlogPostResult> {
+	const config = getContentRepoConfig();
+	const { frontmatter, source } = validateBlogDocument(input);
+	const readTime = calculateBlogReadTimeFromContent(input.content);
+	const markdownPath = `blog/${frontmatter.slug}.md`;
+	const postsIndexPath = 'blog/posts.json';
+
+	const [remoteMarkdown, remotePosts] = await Promise.all([
+		loadGitHubFile(config, markdownPath),
+		loadGitHubFile(config, postsIndexPath)
+	]);
+
+	const remoteMarkdownSource = decodeGitHubContent(remoteMarkdown);
+	if (createBlogSourceChecksum(remoteMarkdownSource) !== input.originalChecksum) {
+		throw new PublishError(
+			'This post changed in the content repo since you opened the editor. Refresh to load the latest version before saving again.',
+			409
+		);
+	}
+
+	const nextPostsJson = updatePostsIndex(
+		decodeGitHubContent(remotePosts),
+		frontmatter,
+		input.content
+	);
+	const commit = await createCommit(
+		config,
+		[
+			{ path: markdownPath, content: source },
+			{ path: postsIndexPath, content: nextPostsJson }
+		],
+		`Edit blog post: ${frontmatter.slug}`
+	);
+
+	const deployTriggered = await triggerVercelDeploy();
+
+	return {
+		commitSha: commit.sha,
+		commitUrl: commit.html_url,
+		deployTriggered,
+		checksum: createBlogSourceChecksum(source),
+		readTime
+	};
+}

--- a/src/lib/server/owner-session.ts
+++ b/src/lib/server/owner-session.ts
@@ -1,0 +1,224 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import type { Cookies } from '@sveltejs/kit';
+import { dev } from '$app/environment';
+import { env } from '$env/dynamic/private';
+
+const OWNER_SESSION_COOKIE = 'owner_session';
+const OWNER_STATE_COOKIE = 'owner_oauth_state';
+const OWNER_SESSION_MAX_AGE = 60 * 60 * 24 * 7;
+const OWNER_STATE_MAX_AGE = 60 * 10;
+
+type OwnerTokenPayload = {
+	login: string;
+	id: number;
+	name: string | null;
+	avatarUrl: string | null;
+	expiresAt: number;
+};
+
+type OAuthStatePayload = {
+	redirectTo: string;
+	nonce: string;
+	expiresAt: number;
+};
+
+export interface OwnerSession {
+	login: string;
+	id: number;
+	name: string | null;
+	avatarUrl: string | null;
+	expiresAt: number;
+}
+
+export interface GitHubOwnerProfile {
+	login: string;
+	id: number;
+	name?: string | null;
+	avatar_url?: string | null;
+}
+
+function getCookieOptions(maxAge: number) {
+	return {
+		path: '/',
+		httpOnly: true,
+		sameSite: 'lax' as const,
+		secure: !dev,
+		maxAge
+	};
+}
+
+function base64UrlEncode(value: string): string {
+	return Buffer.from(value, 'utf-8').toString('base64url');
+}
+
+function base64UrlDecode(value: string): string {
+	return Buffer.from(value, 'base64url').toString('utf-8');
+}
+
+function getOwnerSessionSecret(): string | null {
+	return env['OWNER_SESSION_SECRET']?.trim() || null;
+}
+
+function signValue(value: string, secret: string): string {
+	return createHmac('sha256', secret).update(value).digest('base64url');
+}
+
+function createSignedToken<T extends Record<string, unknown>>(payload: T, secret: string): string {
+	const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+	return `${encodedPayload}.${signValue(encodedPayload, secret)}`;
+}
+
+function readSignedToken<T extends { expiresAt: number }>(token: string, secret: string): T | null {
+	const [encodedPayload, signature] = token.split('.');
+	if (!encodedPayload || !signature) {
+		return null;
+	}
+
+	const expectedSignature = signValue(encodedPayload, secret);
+	const receivedSignature = Buffer.from(signature);
+	const calculatedSignature = Buffer.from(expectedSignature);
+
+	if (
+		receivedSignature.length !== calculatedSignature.length ||
+		!timingSafeEqual(receivedSignature, calculatedSignature)
+	) {
+		return null;
+	}
+
+	try {
+		const payload = JSON.parse(base64UrlDecode(encodedPayload)) as T;
+		if (payload.expiresAt <= Date.now()) {
+			return null;
+		}
+
+		return payload;
+	} catch {
+		return null;
+	}
+}
+
+export function getOwnerAuthConfiguration() {
+	return {
+		clientId: env['GITHUB_OAUTH_CLIENT_ID']?.trim() || '',
+		clientSecret: env['GITHUB_OAUTH_CLIENT_SECRET']?.trim() || '',
+		allowedLogin: env['OWNER_GITHUB_LOGIN']?.trim() || '',
+		allowedId: env['OWNER_GITHUB_ID']?.trim() || ''
+	};
+}
+
+export function isOwnerAuthConfigured(): boolean {
+	const config = getOwnerAuthConfiguration();
+	return Boolean(
+		config.clientId &&
+		config.clientSecret &&
+		(config.allowedLogin || config.allowedId) &&
+		getOwnerSessionSecret()
+	);
+}
+
+export function createOwnerOAuthState(redirectTo: string): string {
+	const secret = getOwnerSessionSecret();
+	if (!secret) {
+		throw new Error('OWNER_SESSION_SECRET is not configured');
+	}
+
+	const payload: OAuthStatePayload = {
+		redirectTo: sanitizeRedirectTo(redirectTo),
+		nonce: randomBytes(16).toString('hex'),
+		expiresAt: Date.now() + OWNER_STATE_MAX_AGE * 1000
+	};
+
+	return createSignedToken(payload, secret);
+}
+
+export function storeOwnerOAuthState(cookies: Cookies, state: string): void {
+	cookies.set(OWNER_STATE_COOKIE, state, getCookieOptions(OWNER_STATE_MAX_AGE));
+}
+
+export function readOwnerOAuthState(cookies: Cookies, state: string): OAuthStatePayload | null {
+	const secret = getOwnerSessionSecret();
+	const cookieState = cookies.get(OWNER_STATE_COOKIE);
+	cookies.delete(OWNER_STATE_COOKIE, { path: '/' });
+
+	if (!secret || !cookieState || cookieState !== state) {
+		return null;
+	}
+
+	return readSignedToken<OAuthStatePayload>(state, secret);
+}
+
+export function createOwnerSessionToken(profile: GitHubOwnerProfile): string {
+	const secret = getOwnerSessionSecret();
+	if (!secret) {
+		throw new Error('OWNER_SESSION_SECRET is not configured');
+	}
+
+	return createSignedToken<OwnerTokenPayload>(
+		{
+			login: profile.login,
+			id: profile.id,
+			name: profile.name ?? null,
+			avatarUrl: profile.avatar_url ?? null,
+			expiresAt: Date.now() + OWNER_SESSION_MAX_AGE * 1000
+		},
+		secret
+	);
+}
+
+export function setOwnerSession(cookies: Cookies, profile: GitHubOwnerProfile): void {
+	cookies.set(
+		OWNER_SESSION_COOKIE,
+		createOwnerSessionToken(profile),
+		getCookieOptions(OWNER_SESSION_MAX_AGE)
+	);
+}
+
+export function clearOwnerSession(cookies: Cookies): void {
+	cookies.delete(OWNER_SESSION_COOKIE, { path: '/' });
+	cookies.delete(OWNER_STATE_COOKIE, { path: '/' });
+}
+
+export function readOwnerSession(cookies: Cookies): OwnerSession | null {
+	const secret = getOwnerSessionSecret();
+	const token = cookies.get(OWNER_SESSION_COOKIE);
+	if (!secret || !token) {
+		return null;
+	}
+
+	const payload = readSignedToken<OwnerTokenPayload>(token, secret);
+	if (!payload) {
+		return null;
+	}
+
+	return {
+		login: payload.login,
+		id: payload.id,
+		name: payload.name,
+		avatarUrl: payload.avatarUrl,
+		expiresAt: payload.expiresAt
+	};
+}
+
+export function isAllowedOwner(profile: GitHubOwnerProfile): boolean {
+	const { allowedLogin, allowedId } = getOwnerAuthConfiguration();
+	const normalizedLogin = allowedLogin.toLowerCase();
+	const normalizedAllowedId = allowedId ? Number(allowedId) : null;
+
+	if (normalizedLogin && profile.login.toLowerCase() !== normalizedLogin) {
+		return false;
+	}
+
+	if (normalizedAllowedId && profile.id !== normalizedAllowedId) {
+		return false;
+	}
+
+	return Boolean(normalizedLogin || normalizedAllowedId);
+}
+
+export function sanitizeRedirectTo(redirectTo: string | null | undefined): string {
+	if (!redirectTo || !redirectTo.startsWith('/') || redirectTo.startsWith('//')) {
+		return '/owner';
+	}
+
+	return redirectTo;
+}

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -208,7 +208,8 @@
 			};
 			editorChecksum = saveResult.checksum;
 			editorCommitUrl = saveResult.commitUrl;
-			editorNotice = 'Saved to teenylilcontent. Your existing site deploy should publish it automatically.';
+			editorNotice =
+				'Saved to teenylilcontent. Your existing site deploy should publish it automatically.';
 		} catch (caughtError) {
 			editorError =
 				caughtError instanceof Error ? caughtError.message : 'Failed to save blog post.';

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -207,7 +207,8 @@
 			};
 			editorChecksum = saveResult.checksum;
 			editorCommitUrl = saveResult.commitUrl;
-			editorNotice = 'Saved to teenylilcontent. Your existing site deploy should publish it automatically.';
+			editorNotice =
+				'Saved to teenylilcontent. Your existing site deploy should publish it automatically.';
 		} catch (caughtError) {
 			editorError =
 				caughtError instanceof Error ? caughtError.message : 'Failed to save blog post.';

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -3,7 +3,7 @@
 	import BlogMarkdownContent from '$lib/components/blog-markdown-content.svelte';
 	import type { BlogPost } from '$lib/content/blog';
 	import type { BlogFrontmatter } from '$lib/content/blog-source';
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 
 	type OwnerStatus = {
 		isOwner: boolean;
@@ -52,6 +52,109 @@
 	let editorError = '';
 	let editorNotice = '';
 	let editorCommitUrl = '';
+	let editorSourceInput: HTMLTextAreaElement | null = null;
+	let editorPreviewScrollRegion: HTMLElement | null = null;
+	let previewContentResizeObserver: ResizeObserver | null = null;
+	let isProgrammaticScrollSync = false;
+	let scrollSyncResetFrame = 0;
+
+	function getScrollProgress(element: HTMLElement) {
+		const maxScrollTop = element.scrollHeight - element.clientHeight;
+		return maxScrollTop > 0 ? element.scrollTop / maxScrollTop : 0;
+	}
+
+	function setScrollProgress(element: HTMLElement, progress: number) {
+		const maxScrollTop = element.scrollHeight - element.clientHeight;
+		if (maxScrollTop <= 0) {
+			element.scrollTop = 0;
+			return;
+		}
+
+		element.scrollTop = Math.min(Math.max(progress, 0), 1) * maxScrollTop;
+	}
+
+	function runWithScrollSyncGuard(callback: () => void) {
+		if (typeof window === 'undefined') {
+			callback();
+			return;
+		}
+
+		isProgrammaticScrollSync = true;
+		callback();
+		window.cancelAnimationFrame(scrollSyncResetFrame);
+		scrollSyncResetFrame = window.requestAnimationFrame(() => {
+			isProgrammaticScrollSync = false;
+		});
+	}
+
+	function syncScrollPosition(source: HTMLElement, target: HTMLElement) {
+		runWithScrollSyncGuard(() => {
+			setScrollProgress(target, getScrollProgress(source));
+		});
+	}
+
+	function handleSourceScroll() {
+		if (isProgrammaticScrollSync || !editorSourceInput || !editorPreviewScrollRegion) {
+			return;
+		}
+
+		syncScrollPosition(editorSourceInput, editorPreviewScrollRegion);
+	}
+
+	function handlePreviewScroll() {
+		if (isProgrammaticScrollSync || !editorSourceInput || !editorPreviewScrollRegion) {
+			return;
+		}
+
+		syncScrollPosition(editorPreviewScrollRegion, editorSourceInput);
+	}
+
+	function clearPreviewResizeObserver() {
+		previewContentResizeObserver?.disconnect();
+		previewContentResizeObserver = null;
+	}
+
+	function teardownScrollSync() {
+		clearPreviewResizeObserver();
+		if (typeof window !== 'undefined') {
+			window.cancelAnimationFrame(scrollSyncResetFrame);
+		}
+		isProgrammaticScrollSync = false;
+	}
+
+	async function setupScrollSync() {
+		await tick();
+
+		if (!editorSourceInput || !editorPreviewScrollRegion) {
+			return;
+		}
+
+		clearPreviewResizeObserver();
+
+		const previewContent = editorPreviewScrollRegion.firstElementChild;
+		if (previewContent && typeof ResizeObserver !== 'undefined') {
+			previewContentResizeObserver = new ResizeObserver(() => {
+				if (!editorSourceInput || !editorPreviewScrollRegion) {
+					return;
+				}
+
+				syncScrollPosition(editorSourceInput, editorPreviewScrollRegion);
+			});
+			previewContentResizeObserver.observe(previewContent);
+		}
+
+		syncScrollPosition(editorSourceInput, editorPreviewScrollRegion);
+	}
+
+	async function syncPreviewToSource() {
+		await tick();
+
+		if (!editorSourceInput || !editorPreviewScrollRegion) {
+			return;
+		}
+
+		syncScrollPosition(editorSourceInput, editorPreviewScrollRegion);
+	}
 
 	function estimateReadTime(content: string): string {
 		const wordCount = content.match(/\b[\w'-]+\b/g)?.length ?? 0;
@@ -77,6 +180,11 @@
 					content: editorDraft.content,
 					readTime: estimateReadTime(editorDraft.content)
 				};
+
+	$: if (isEditMode && editorDraft) {
+		editorDraft.content;
+		void syncPreviewToSource();
+	}
 
 	function replaceEditQuery(isEditing: boolean) {
 		if (typeof window === 'undefined') {
@@ -133,6 +241,7 @@
 			editorChecksum = editablePost.checksum;
 			isEditMode = true;
 			replaceEditQuery(true);
+			await setupScrollSync();
 		} catch (caughtError) {
 			editorError =
 				caughtError instanceof Error ? caughtError.message : 'Failed to open the blog editor.';
@@ -142,6 +251,7 @@
 	}
 
 	function closeEditor() {
+		teardownScrollSync();
 		isEditMode = false;
 		editorError = '';
 		editorNotice = '';
@@ -228,6 +338,10 @@
 				await openEditor();
 			}
 		})();
+
+		return () => {
+			teardownScrollSync();
+		};
 	});
 </script>
 
@@ -402,7 +516,11 @@
 
 					<label class="editor-field editor-markdown-field">
 						<span class="editor-field-label">Markdown source</span>
-						<textarea bind:value={editorDraft.content} class="editor-textarea editor-markdown-input"
+						<textarea
+							bind:this={editorSourceInput}
+							bind:value={editorDraft.content}
+							class="editor-textarea editor-markdown-input"
+							on:scroll={handleSourceScroll}
 						></textarea>
 					</label>
 				</form>
@@ -414,10 +532,16 @@
 							This uses the same renderer and prose styles as the live post.
 						</p>
 					</div>
-					<BlogMarkdownContent
-						markdown={editorDraft.content}
-						contentClass="prose editor-preview-content"
-					/>
+					<div
+						class="editor-preview-scroll-region"
+						bind:this={editorPreviewScrollRegion}
+						on:scroll={handlePreviewScroll}
+					>
+						<BlogMarkdownContent
+							markdown={editorDraft.content}
+							contentClass="prose editor-preview-content"
+						/>
+					</div>
 				</section>
 			</div>
 		{:else}
@@ -651,6 +775,18 @@
 			Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 	}
 
+	.preview-pane {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.editor-preview-scroll-region {
+		overflow: auto;
+		min-height: 32rem;
+		max-height: 70vh;
+		padding-right: 0.35rem;
+	}
+
 	.preview-pane :global(.editor-preview-content) {
 		margin: 0;
 		max-width: none;
@@ -696,6 +832,10 @@
 		.preview-pane {
 			position: sticky;
 			top: 2rem;
+		}
+
+		.editor-preview-scroll-region {
+			max-height: calc(100vh - 8rem);
 		}
 	}
 

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -1,135 +1,264 @@
 <script lang="ts">
-	import '$lib/styles/prose.css';
 	import BlogHeader from '$lib/components/blog-header.svelte';
+	import BlogMarkdownContent from '$lib/components/blog-markdown-content.svelte';
 	import type { BlogPost } from '$lib/content/blog';
-	import { onMount, tick } from 'svelte';
-	import { Marked } from 'marked';
-	import { markedHighlight } from 'marked-highlight';
-	import hljs from 'highlight.js/lib/core';
-	import typescript from 'highlight.js/lib/languages/typescript';
-	import javascript from 'highlight.js/lib/languages/javascript';
-	import plaintext from 'highlight.js/lib/languages/plaintext';
+	import type { BlogFrontmatter } from '$lib/content/blog-source';
+	import { onMount } from 'svelte';
 
-	// Register languages
-	hljs.registerLanguage('typescript', typescript);
-	hljs.registerLanguage('javascript', javascript);
-	hljs.registerLanguage('plaintext', plaintext);
-	import { subAndSuper, createTOC } from '$lib/notion/utils/blog-helpers';
-
-	let context: HTMLElement;
-
-	const runBlogHelpers = async () => {
-		await tick();
-		if (context) {
-			subAndSuper(context);
-			createTOC();
-		}
+	type OwnerStatus = {
+		isOwner: boolean;
+		owner: {
+			login: string;
+			name: string | null;
+			avatarUrl: string | null;
+		} | null;
+		authConfigured: boolean;
+		publishConfigured: boolean;
+		deployConfigured: boolean;
 	};
 
-	const setupInlineVideos = () => {
-		if (!context || typeof IntersectionObserver === 'undefined') {
-			return () => {};
-		}
+	type EditableBlogResponse = {
+		frontmatter: BlogFrontmatter;
+		content: string;
+		checksum: string;
+	};
 
-		const videos = Array.from(
-			context.querySelectorAll<HTMLVideoElement>('.session-interlude-video')
-		);
+	type EditorDraft = BlogFrontmatter & {
+		content: string;
+	};
 
-		if (!videos.length) {
-			return () => {};
-		}
-
-		videos.forEach((video) => {
-			video.controls = false;
-			video.muted = true;
-			video.loop = true;
-			video.playsInline = true;
-		});
-
-		const observer = new IntersectionObserver(
-			(entries) => {
-				entries.forEach((entry) => {
-					const video = entry.target as HTMLVideoElement;
-
-					if (entry.isIntersecting) {
-						void video.play().catch(() => {});
-						return;
-					}
-
-					video.pause();
-				});
-			},
-			{ threshold: 0.5 }
-		);
-
-		videos.forEach((video) => observer.observe(video));
-
-		return () => {
-			observer.disconnect();
-			videos.forEach((video) => video.pause());
-		};
+	type SaveBlogResponse = {
+		commitSha: string;
+		commitUrl: string;
+		deployTriggered: boolean;
+		checksum: string;
+		readTime: string;
 	};
 
 	export let data: { post: BlogPost };
 
-	const { post } = data;
+	let post: BlogPost = data.post;
+	let displayedPost: BlogPost = post;
+	let ownerStatus: OwnerStatus = {
+		isOwner: false,
+		owner: null,
+		authConfigured: false,
+		publishConfigured: false,
+		deployConfigured: false
+	};
+	let ownerStatusLoaded = false;
+	let editorDraft: EditorDraft | null = null;
+	let editorChecksum = '';
+	let isEditMode = false;
+	let isLoadingEditor = false;
+	let isSaving = false;
+	let editorError = '';
+	let editorNotice = '';
+	let editorCommitUrl = '';
 
-	// Configure marked with syntax highlighting
-	const marked = new Marked(
-		markedHighlight({
-			emptyLangClass: 'hljs',
-			langPrefix: 'hljs language-',
-			highlight(code, lang) {
-				const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-				return hljs.highlight(code, { language }).value;
+	function estimateReadTime(content: string): string {
+		const wordCount = content.match(/\b[\w'-]+\b/g)?.length ?? 0;
+		const minutes = Math.max(1, Math.ceil(wordCount / 225));
+		return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+	}
+
+	$: displayedPost =
+		!isEditMode || !editorDraft
+			? post
+			: {
+					...post,
+					title: editorDraft.title || post.title,
+					subtitle: editorDraft.subtitle,
+					summary: editorDraft.summary,
+					ogDescription: editorDraft.ogDescription,
+					category: editorDraft.category,
+					publicationDate: editorDraft.publicationDate,
+					formattedPublicationDate: editorDraft.formattedPublicationDate,
+					coverImage: editorDraft.coverImage,
+					coverImageCaption: editorDraft.coverImageCaption,
+					notionId: editorDraft.notionId,
+					content: editorDraft.content,
+					readTime: estimateReadTime(editorDraft.content)
+				};
+
+	function replaceEditQuery(isEditing: boolean) {
+		if (typeof window === 'undefined') {
+			return;
+		}
+
+		const nextUrl = new URL(window.location.href);
+		if (isEditing) {
+			nextUrl.searchParams.set('edit', '1');
+		} else {
+			nextUrl.searchParams.delete('edit');
+		}
+
+		window.history.replaceState({}, '', nextUrl);
+	}
+
+	async function fetchOwnerStatus() {
+		try {
+			const response = await fetch('/api/owner/session');
+			if (!response.ok) {
+				throw new Error('Failed to check owner mode.');
 			}
-		})
-	);
 
-	// Convert markdown to HTML
-	const htmlContent = marked.parse(post.content);
+			ownerStatus = (await response.json()) as OwnerStatus;
+		} catch (caughtError) {
+			editorError =
+				caughtError instanceof Error ? caughtError.message : 'Failed to check owner mode.';
+		} finally {
+			ownerStatusLoaded = true;
+		}
+	}
+
+	async function openEditor() {
+		if (!ownerStatus.isOwner || isLoadingEditor) {
+			return;
+		}
+
+		isLoadingEditor = true;
+		editorError = '';
+		editorNotice = '';
+
+		try {
+			const response = await fetch(`/api/content/blog/${post.slug}`);
+			if (!response.ok) {
+				const failure = (await response.json().catch(() => null)) as { message?: string } | null;
+				throw new Error(failure?.message ?? 'Failed to load editable blog source.');
+			}
+
+			const editablePost = (await response.json()) as EditableBlogResponse;
+			editorDraft = {
+				...editablePost.frontmatter,
+				content: editablePost.content
+			};
+			editorChecksum = editablePost.checksum;
+			isEditMode = true;
+			replaceEditQuery(true);
+		} catch (caughtError) {
+			editorError =
+				caughtError instanceof Error ? caughtError.message : 'Failed to open the blog editor.';
+		} finally {
+			isLoadingEditor = false;
+		}
+	}
+
+	function closeEditor() {
+		isEditMode = false;
+		editorError = '';
+		editorNotice = '';
+		editorCommitUrl = '';
+		replaceEditQuery(false);
+	}
+
+	async function saveEditor() {
+		if (!editorDraft || isSaving) {
+			return;
+		}
+
+		isSaving = true;
+		editorError = '';
+		editorNotice = '';
+		editorCommitUrl = '';
+
+		try {
+			const response = await fetch(`/api/content/blog/${post.slug}/save`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					frontmatter: {
+						title: editorDraft.title,
+						slug: editorDraft.slug,
+						subtitle: editorDraft.subtitle,
+						summary: editorDraft.summary,
+						ogDescription: editorDraft.ogDescription,
+						category: editorDraft.category,
+						publicationDate: editorDraft.publicationDate,
+						formattedPublicationDate: editorDraft.formattedPublicationDate,
+						coverImage: editorDraft.coverImage,
+						coverImageCaption: editorDraft.coverImageCaption,
+						notionId: editorDraft.notionId
+					},
+					content: editorDraft.content,
+					originalChecksum: editorChecksum
+				})
+			});
+
+			if (!response.ok) {
+				const failure = (await response.json().catch(() => null)) as { message?: string } | null;
+				throw new Error(failure?.message ?? 'Failed to save blog post.');
+			}
+
+			const saveResult = (await response.json()) as SaveBlogResponse;
+			post = {
+				...post,
+				title: editorDraft.title,
+				subtitle: editorDraft.subtitle,
+				summary: editorDraft.summary,
+				ogDescription: editorDraft.ogDescription,
+				category: editorDraft.category,
+				publicationDate: editorDraft.publicationDate,
+				formattedPublicationDate: editorDraft.formattedPublicationDate,
+				coverImage: editorDraft.coverImage,
+				coverImageCaption: editorDraft.coverImageCaption,
+				notionId: editorDraft.notionId,
+				content: editorDraft.content,
+				readTime: saveResult.readTime
+			};
+			editorChecksum = saveResult.checksum;
+			editorCommitUrl = saveResult.commitUrl;
+			editorNotice = saveResult.deployTriggered
+				? 'Saved to teenylilcontent and triggered a new Vercel deployment.'
+				: 'Saved to teenylilcontent. Add VERCEL_DEPLOY_HOOK_URL to auto-trigger a Vercel deploy after save.';
+		} catch (caughtError) {
+			editorError =
+				caughtError instanceof Error ? caughtError.message : 'Failed to save blog post.';
+		} finally {
+			isSaving = false;
+		}
+	}
 
 	onMount(() => {
-		let cleanup = () => {};
-
 		void (async () => {
-			await runBlogHelpers();
-			cleanup = setupInlineVideos();
+			await fetchOwnerStatus();
+			if (
+				typeof window !== 'undefined' &&
+				ownerStatus.isOwner &&
+				new URL(window.location.href).searchParams.get('edit') === '1'
+			) {
+				await openEditor();
+			}
 		})();
-
-		return () => {
-			cleanup();
-		};
 	});
 </script>
 
 <svelte:head>
-	<title>{post.title || 'Blog'}</title>
-	<meta name="og:title" content={post.title || 'Blog'} />
-	<meta name="description" content={post.ogDescription} />
+	<title>{displayedPost.title || 'Blog'}</title>
+	<meta name="og:title" content={displayedPost.title || 'Blog'} />
+	<meta name="description" content={displayedPost.ogDescription} />
 
-	<!-- Facebook Meta Tags -->
-	<meta property="og:url" content="https://www.alicealexandra.com/blog/{post.slug}" />
+	<meta property="og:url" content="https://www.alicealexandra.com/blog/{displayedPost.slug}" />
 	<meta property="og:type" content="website" />
-	<meta property="og:title" content="Blog - {post.title || 'Blog'}" />
-	<meta property="og:description" content={post.ogDescription} />
-	<meta property="og:image" content={post.coverImage || 'https://unsplash.it/1200/600'} />
+	<meta property="og:title" content="Blog - {displayedPost.title || 'Blog'}" />
+	<meta property="og:description" content={displayedPost.ogDescription} />
+	<meta property="og:image" content={displayedPost.coverImage || 'https://unsplash.it/1200/600'} />
 
-	<!-- Twitter Meta Tags -->
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:site" content="@tempoimmaterial" />
 	<meta name="twitter:creator" content="@tempoimmaterial" />
 	<meta name="twitter:domain" content="alicealexandra.com" />
 	<meta name="twitter:url" content="https://www.alicealexandra.com/blog" />
-	<meta name="twitter:title" content="Blog - {post.title || 'Blog'}" />
-	<meta name="twitter:description" content={post.ogDescription} />
-	<meta name="twitter:image" content={post.coverImage || 'https://unsplash.it/1200/600'} />
+	<meta name="twitter:title" content="Blog - {displayedPost.title || 'Blog'}" />
+	<meta name="twitter:description" content={displayedPost.ogDescription} />
+	<meta name="twitter:image" content={displayedPost.coverImage || 'https://unsplash.it/1200/600'} />
 	<meta
 		name="twitter:image:alt"
-		content="Open graph representation of this blog article, {post.title || 'Blog'}."
+		content="Open graph representation of this blog article, {displayedPost.title || 'Blog'}."
 	/>
 
-	<!-- Highlight.js themes - auto-switch based on color scheme -->
 	<link
 		rel="stylesheet"
 		href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css"
@@ -144,21 +273,161 @@
 
 <div class="page-wrapper">
 	<BlogHeader
-		title={post.title}
-		subtitle={post.subtitle}
-		category={post.category || 'Article'}
-		publishedDate={post.formattedPublicationDate}
-		readTime={post.readTime}
+		title={displayedPost.title}
+		subtitle={displayedPost.subtitle}
+		category={displayedPost.category || 'Article'}
+		publishedDate={displayedPost.formattedPublicationDate}
+		readTime={displayedPost.readTime}
 	/>
 
 	<div class="blog-container">
-		{#if htmlContent}
-			<div class="prose" bind:this={context}>
-				{@html htmlContent}
+		{#if ownerStatusLoaded && ownerStatus.isOwner}
+			<div class="editor-toolbar">
+				<div class="editor-toolbar-copy">
+					<p class="editor-toolbar-kicker">Owner mode</p>
+					<p class="editor-toolbar-text">
+						{#if isEditMode}
+							Editing <strong>{post.slug}.md</strong> in teenylilcontent.
+						{:else}
+							Signed in as <strong>{ownerStatus.owner?.name || ownerStatus.owner?.login}</strong>.
+						{/if}
+					</p>
+				</div>
+				<div class="editor-toolbar-actions">
+					<a class="editor-action secondary" href="/owner">Owner</a>
+					{#if isEditMode}
+						<button
+							class="editor-action secondary"
+							type="button"
+							on:click={closeEditor}
+							disabled={isSaving}
+						>
+							Cancel
+						</button>
+						<button
+							class="editor-action primary"
+							type="button"
+							on:click={saveEditor}
+							disabled={isSaving}
+						>
+							{isSaving ? 'Saving…' : 'Save & publish'}
+						</button>
+					{:else}
+						<button
+							class="editor-action primary"
+							type="button"
+							on:click={openEditor}
+							disabled={isLoadingEditor}
+						>
+							{isLoadingEditor ? 'Loading…' : 'Edit'}
+						</button>
+					{/if}
+				</div>
+			</div>
+		{/if}
+
+		{#if editorError}
+			<div class="editor-feedback editor-feedback-error">{editorError}</div>
+		{/if}
+
+		{#if editorNotice}
+			<div class="editor-feedback editor-feedback-success">
+				<span>{editorNotice}</span>
+				{#if editorCommitUrl}
+					<a href={editorCommitUrl} target="_blank" rel="noreferrer">View commit</a>
+				{/if}
+			</div>
+		{/if}
+
+		{#if isEditMode && editorDraft}
+			<div class="editor-layout">
+				<form class="editor-pane editor-form" on:submit|preventDefault={saveEditor}>
+					<div class="editor-pane-header">
+						<h2 class="editor-pane-title">Edit source</h2>
+						<p class="editor-pane-copy">
+							Use normal markdown punctuation like <code>_</code>, <code>**</code>, headings, lists,
+							and fences.
+						</p>
+					</div>
+
+					<div class="editor-metadata-grid">
+						<label class="editor-field editor-field-wide">
+							<span class="editor-field-label">Title</span>
+							<input bind:value={editorDraft.title} class="editor-input" type="text" />
+						</label>
+						<label class="editor-field editor-field-wide">
+							<span class="editor-field-label">Subtitle</span>
+							<input bind:value={editorDraft.subtitle} class="editor-input" type="text" />
+						</label>
+						<label class="editor-field">
+							<span class="editor-field-label">Category</span>
+							<input bind:value={editorDraft.category} class="editor-input" type="text" />
+						</label>
+						<label class="editor-field">
+							<span class="editor-field-label">Publication date</span>
+							<input bind:value={editorDraft.publicationDate} class="editor-input" type="date" />
+						</label>
+						<label class="editor-field editor-field-wide">
+							<span class="editor-field-label">Formatted publication date</span>
+							<input
+								bind:value={editorDraft.formattedPublicationDate}
+								class="editor-input"
+								type="text"
+							/>
+						</label>
+						<label class="editor-field editor-field-wide">
+							<span class="editor-field-label">Summary</span>
+							<textarea
+								bind:value={editorDraft.summary}
+								class="editor-textarea editor-meta-textarea"
+							></textarea>
+						</label>
+						<label class="editor-field editor-field-wide">
+							<span class="editor-field-label">Open graph description</span>
+							<textarea
+								bind:value={editorDraft.ogDescription}
+								class="editor-textarea editor-meta-textarea"
+							></textarea>
+						</label>
+						<label class="editor-field editor-field-wide">
+							<span class="editor-field-label">Cover image URL</span>
+							<input bind:value={editorDraft.coverImage} class="editor-input" type="url" />
+						</label>
+						<label class="editor-field editor-field-wide">
+							<span class="editor-field-label">Cover image caption</span>
+							<input bind:value={editorDraft.coverImageCaption} class="editor-input" type="text" />
+						</label>
+					</div>
+
+					<div class="editor-readonly-row">
+						<p><span>Slug</span><strong>{editorDraft.slug}</strong></p>
+						<p><span>Notion ID</span><strong>{editorDraft.notionId}</strong></p>
+					</div>
+
+					<label class="editor-field editor-markdown-field">
+						<span class="editor-field-label">Markdown source</span>
+						<textarea bind:value={editorDraft.content} class="editor-textarea editor-markdown-input"
+						></textarea>
+					</label>
+				</form>
+
+				<section class="editor-pane preview-pane">
+					<div class="editor-pane-header">
+						<h2 class="editor-pane-title">Live preview</h2>
+						<p class="editor-pane-copy">
+							This uses the same renderer and prose styles as the live post.
+						</p>
+					</div>
+					<BlogMarkdownContent
+						markdown={editorDraft.content}
+						contentClass="prose editor-preview-content"
+					/>
+				</section>
 			</div>
 		{:else}
-			<p>No content available.</p>
+			<BlogMarkdownContent markdown={post.content} />
 		{/if}
+
 		<p class="back-link">
 			<a href="/blog" data-sveltekit-noscroll>back.</a>
 		</p>
@@ -198,6 +467,7 @@
 
 		@media (min-width: 1280px) {
 			padding: var(--content-space-xl) var(--content-space-xl);
+			max-width: 1320px;
 		}
 
 		@media (min-width: 1536px) {
@@ -205,8 +475,7 @@
 		}
 	}
 
-	/* Styles for constraining non-prose sections */
-	.blog-container > div:not(.prose) {
+	.blog-container > div:not(.prose):not(.editor-layout):not(.editor-toolbar):not(.editor-feedback) {
 		margin: 0 auto;
 		width: 100%;
 		max-width: 900px;
@@ -215,6 +484,180 @@
 		@media (min-width: 1024px) {
 			font-size: var(--content-font-size-body-lg);
 		}
+	}
+
+	.editor-toolbar,
+	.editor-feedback {
+		margin: 0 auto 1.5rem;
+		border: 1px solid var(--color-content-border);
+		background: color-mix(in srgb, var(--color-content-bg) 92%, var(--color-content-text) 8%);
+		padding: 1rem;
+	}
+
+	.editor-toolbar {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.editor-toolbar-kicker {
+		margin: 0 0 0.25rem;
+		color: var(--color-content-secondary);
+		font-size: var(--content-font-size-body-sm);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.editor-toolbar-text,
+	.editor-feedback,
+	.editor-pane-copy,
+	.editor-field-label,
+	.editor-readonly-row {
+		font-size: var(--content-font-size-body-sm);
+		line-height: 1.5;
+	}
+
+	.editor-toolbar-text,
+	.editor-pane-copy {
+		margin: 0;
+	}
+
+	.editor-toolbar-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+
+	.editor-action {
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+		cursor: pointer;
+		border: 1px solid var(--color-content-border);
+		background: transparent;
+		padding: 0.7rem 1rem;
+		color: var(--color-content-text);
+		font: inherit;
+		text-decoration: none;
+	}
+
+	.editor-action.primary {
+		background: var(--color-content-text);
+		color: var(--color-content-bg);
+	}
+
+	.editor-action:disabled {
+		opacity: 0.6;
+		cursor: wait;
+	}
+
+	.editor-feedback {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.editor-feedback a {
+		color: inherit;
+	}
+
+	.editor-feedback-error {
+		border-color: var(--color-content-link);
+	}
+
+	.editor-layout {
+		display: grid;
+		gap: 1.5rem;
+		margin-bottom: 2rem;
+	}
+
+	.editor-pane {
+		border: 1px solid var(--color-content-border);
+		background: color-mix(in srgb, var(--color-content-bg) 96%, var(--color-content-text) 4%);
+		padding: 1rem;
+		min-width: 0;
+	}
+
+	.editor-pane-header {
+		margin-bottom: 1rem;
+	}
+
+	.editor-pane-title {
+		margin: 0 0 0.35rem;
+		font-size: 1.35rem;
+		font-family: var(--font-serif);
+	}
+
+	.editor-metadata-grid {
+		display: grid;
+		gap: 0.85rem;
+	}
+
+	.editor-field {
+		display: grid;
+		gap: 0.4rem;
+	}
+
+	.editor-field-wide {
+		grid-column: 1 / -1;
+	}
+
+	.editor-field-label {
+		color: var(--color-content-secondary);
+	}
+
+	.editor-input,
+	.editor-textarea {
+		border: 1px solid var(--color-content-border);
+		background: var(--color-content-bg);
+		padding: 0.8rem;
+		width: 100%;
+		color: var(--color-content-text);
+		font: inherit;
+	}
+
+	.editor-meta-textarea {
+		min-height: 5.5rem;
+		resize: vertical;
+	}
+
+	.editor-readonly-row {
+		display: grid;
+		gap: 0.75rem;
+		margin: 1rem 0;
+		border-top: 1px solid var(--color-content-border);
+		padding-top: 1rem;
+		color: var(--color-content-secondary);
+	}
+
+	.editor-readonly-row p {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		margin: 0;
+	}
+
+	.editor-readonly-row strong {
+		color: var(--color-content-text);
+		font-weight: 500;
+		font-size: var(--content-font-size-body);
+	}
+
+	.editor-markdown-input {
+		min-height: 32rem;
+		resize: vertical;
+		font-size: 0.95rem;
+		line-height: 1.7;
+		font-family:
+			'SFMono-Regular', 'SFMono-Regular Fallback', ui-monospace, 'Cascadia Code', 'Roboto Mono',
+			Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+	}
+
+	.preview-pane :global(.editor-preview-content) {
+		margin: 0;
+		max-width: none;
 	}
 
 	.back-link {
@@ -235,6 +678,44 @@
 			padding: var(--content-space-md);
 			color: var(--color-content-text);
 			font-family: var(--font-serif);
+		}
+	}
+
+	@media (min-width: 768px) {
+		.editor-metadata-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.editor-readonly-row {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
+	@media (min-width: 1280px) {
+		.editor-layout {
+			grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+			align-items: start;
+		}
+
+		.preview-pane {
+			position: sticky;
+			top: 2rem;
+		}
+	}
+
+	@media (max-width: 767px) {
+		.editor-toolbar,
+		.editor-feedback {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+
+		.editor-toolbar-actions {
+			width: 100%;
+		}
+
+		.editor-action {
+			flex: 1 1 auto;
 		}
 	}
 </style>

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -14,7 +14,6 @@
 		} | null;
 		authConfigured: boolean;
 		publishConfigured: boolean;
-		deployConfigured: boolean;
 	};
 
 	type EditableBlogResponse = {
@@ -43,8 +42,7 @@
 		isOwner: false,
 		owner: null,
 		authConfigured: false,
-		publishConfigured: false,
-		deployConfigured: false
+		publishConfigured: false
 	};
 	let ownerStatusLoaded = false;
 	let editorDraft: EditorDraft | null = null;
@@ -210,9 +208,7 @@
 			};
 			editorChecksum = saveResult.checksum;
 			editorCommitUrl = saveResult.commitUrl;
-			editorNotice = saveResult.deployTriggered
-				? 'Saved to teenylilcontent and triggered a new Vercel deployment.'
-				: 'Saved to teenylilcontent. Add VERCEL_DEPLOY_HOOK_URL to auto-trigger a Vercel deploy after save.';
+			editorNotice = 'Saved to teenylilcontent. Your existing site deploy should publish it automatically.';
 		} catch (caughtError) {
 			editorError =
 				caughtError instanceof Error ? caughtError.message : 'Failed to save blog post.';

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -146,10 +146,15 @@
 		syncScrollPosition(editorSourceInput, editorPreviewScrollRegion);
 	}
 
-	async function syncPreviewToSource() {
+	async function syncPreviewToSource(contentSnapshot: string) {
 		await tick();
 
-		if (!editorSourceInput || !editorPreviewScrollRegion) {
+		if (
+			!editorSourceInput ||
+			!editorPreviewScrollRegion ||
+			!editorDraft ||
+			contentSnapshot !== editorDraft.content
+		) {
 			return;
 		}
 
@@ -182,8 +187,7 @@
 				};
 
 	$: if (isEditMode && editorDraft) {
-		editorDraft.content;
-		void syncPreviewToSource();
+		void syncPreviewToSource(editorDraft.content);
 	}
 
 	function replaceEditQuery(isEditing: boolean) {
@@ -781,10 +785,10 @@
 	}
 
 	.editor-preview-scroll-region {
-		overflow: auto;
+		padding-right: 0.35rem;
 		min-height: 32rem;
 		max-height: 70vh;
-		padding-right: 0.35rem;
+		overflow: auto;
 	}
 
 	.preview-pane :global(.editor-preview-content) {

--- a/src/routes/(landing-pages)/blog/[slug]/+page.svelte
+++ b/src/routes/(landing-pages)/blog/[slug]/+page.svelte
@@ -29,7 +29,6 @@
 	type SaveBlogResponse = {
 		commitSha: string;
 		commitUrl: string;
-		deployTriggered: boolean;
 		checksum: string;
 		readTime: string;
 	};
@@ -208,8 +207,7 @@
 			};
 			editorChecksum = saveResult.checksum;
 			editorCommitUrl = saveResult.commitUrl;
-			editorNotice =
-				'Saved to teenylilcontent. Your existing site deploy should publish it automatically.';
+			editorNotice = 'Saved to teenylilcontent. Your existing site deploy should publish it automatically.';
 		} catch (caughtError) {
 			editorError =
 				caughtError instanceof Error ? caughtError.message : 'Failed to save blog post.';

--- a/src/routes/api/auth/github/+server.ts
+++ b/src/routes/api/auth/github/+server.ts
@@ -1,0 +1,27 @@
+import { redirect, type RequestHandler } from '@sveltejs/kit';
+import {
+	createOwnerOAuthState,
+	getOwnerAuthConfiguration,
+	isOwnerAuthConfigured,
+	sanitizeRedirectTo,
+	storeOwnerOAuthState
+} from '$lib/server/owner-session';
+
+export const GET: RequestHandler = ({ cookies, url }) => {
+	if (!isOwnerAuthConfigured()) {
+		throw redirect(302, '/owner?error=auth-not-configured');
+	}
+
+	const config = getOwnerAuthConfiguration();
+	const redirectTo = sanitizeRedirectTo(url.searchParams.get('redirectTo'));
+	const state = createOwnerOAuthState(redirectTo);
+	const callbackUrl = new URL('/api/auth/github/callback', url.origin);
+	const githubAuthorizeUrl = new URL('https://github.com/login/oauth/authorize');
+	githubAuthorizeUrl.searchParams.set('client_id', config.clientId);
+	githubAuthorizeUrl.searchParams.set('redirect_uri', callbackUrl.toString());
+	githubAuthorizeUrl.searchParams.set('scope', 'read:user');
+	githubAuthorizeUrl.searchParams.set('state', state);
+
+	storeOwnerOAuthState(cookies, state);
+	throw redirect(302, githubAuthorizeUrl.toString());
+};

--- a/src/routes/api/auth/github/callback/+server.ts
+++ b/src/routes/api/auth/github/callback/+server.ts
@@ -1,0 +1,82 @@
+import { error, redirect, type RequestHandler } from '@sveltejs/kit';
+import {
+	clearOwnerSession,
+	getOwnerAuthConfiguration,
+	isAllowedOwner,
+	readOwnerOAuthState,
+	setOwnerSession
+} from '$lib/server/owner-session';
+
+interface GitHubAccessTokenResponse {
+	access_token?: string;
+	error?: string;
+	error_description?: string;
+}
+
+interface GitHubUserResponse {
+	login: string;
+	id: number;
+	name?: string | null;
+	avatar_url?: string | null;
+}
+
+export const GET: RequestHandler = async ({ cookies, fetch, url }) => {
+	const code = url.searchParams.get('code');
+	const state = url.searchParams.get('state');
+
+	if (!code || !state) {
+		throw error(400, 'Missing GitHub OAuth callback parameters.');
+	}
+
+	const statePayload = readOwnerOAuthState(cookies, state);
+	if (!statePayload) {
+		clearOwnerSession(cookies);
+		throw redirect(302, '/owner?error=invalid-state');
+	}
+
+	const config = getOwnerAuthConfiguration();
+	const callbackUrl = new URL('/api/auth/github/callback', url.origin);
+	const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			client_id: config.clientId,
+			client_secret: config.clientSecret,
+			code,
+			redirect_uri: callbackUrl.toString(),
+			state
+		})
+	});
+
+	const tokenData = (await tokenResponse.json()) as GitHubAccessTokenResponse;
+	if (!tokenResponse.ok || !tokenData.access_token) {
+		throw redirect(
+			302,
+			`/owner?error=${encodeURIComponent(tokenData.error ?? 'token-exchange-failed')}`
+		);
+	}
+
+	const userResponse = await fetch('https://api.github.com/user', {
+		headers: {
+			Accept: 'application/vnd.github+json',
+			Authorization: `Bearer ${tokenData.access_token}`,
+			'User-Agent': 'alicealexandra-owner-editor'
+		}
+	});
+
+	if (!userResponse.ok) {
+		throw redirect(302, '/owner?error=github-user-fetch-failed');
+	}
+
+	const user = (await userResponse.json()) as GitHubUserResponse;
+	if (!isAllowedOwner(user)) {
+		clearOwnerSession(cookies);
+		throw redirect(302, '/owner?error=owner-not-authorized');
+	}
+
+	setOwnerSession(cookies, user);
+	throw redirect(302, statePayload.redirectTo);
+};

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -1,0 +1,7 @@
+import { redirect, type RequestHandler } from '@sveltejs/kit';
+import { clearOwnerSession, sanitizeRedirectTo } from '$lib/server/owner-session';
+
+export const GET: RequestHandler = ({ cookies, url }) => {
+	clearOwnerSession(cookies);
+	throw redirect(302, sanitizeRedirectTo(url.searchParams.get('redirectTo')));
+};

--- a/src/routes/api/content/blog/[slug]/+server.ts
+++ b/src/routes/api/content/blog/[slug]/+server.ts
@@ -1,0 +1,25 @@
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import { loadRawBlogMarkdownBySlug } from '$lib/content/blog-source';
+
+export const GET: RequestHandler = async ({ locals, params }) => {
+	if (!locals.isOwner) {
+		throw error(403, 'Owner session required.');
+	}
+
+	const slug = params.slug;
+	if (!slug) {
+		throw error(400, 'Invalid blog slug.');
+	}
+
+	const document = await loadRawBlogMarkdownBySlug(slug);
+	if (!document) {
+		throw error(404, 'Blog post not found.');
+	}
+
+	return json({
+		frontmatter: document.frontmatter,
+		content: document.content,
+		checksum: document.checksum,
+		rawSource: document.rawSource
+	});
+};

--- a/src/routes/api/content/blog/[slug]/save/+server.ts
+++ b/src/routes/api/content/blog/[slug]/save/+server.ts
@@ -1,0 +1,49 @@
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import {
+	normalizeBlogFrontmatter,
+	type BlogFrontmatter,
+	isValidBlogSlug
+} from '$lib/content/blog-source';
+import { PublishError, saveBlogPost } from '$lib/server/blog-publishing';
+
+interface SaveBlogRequest {
+	frontmatter?: Partial<BlogFrontmatter>;
+	content?: string;
+	originalChecksum?: string;
+}
+
+export const POST: RequestHandler = async ({ locals, params, request }) => {
+	if (!locals.isOwner) {
+		throw error(403, 'Owner session required.');
+	}
+
+	const slug = params.slug;
+	if (!slug || !isValidBlogSlug(slug)) {
+		throw error(400, 'Invalid blog slug.');
+	}
+
+	const payload = (await request.json()) as SaveBlogRequest;
+	const content = payload.content;
+	const originalChecksum = payload.originalChecksum;
+
+	if (typeof content !== 'string' || typeof originalChecksum !== 'string') {
+		throw error(400, 'Markdown content and original checksum are required.');
+	}
+
+	try {
+		const result = await saveBlogPost({
+			slug,
+			frontmatter: normalizeBlogFrontmatter(payload.frontmatter ?? {}, slug),
+			content,
+			originalChecksum
+		});
+
+		return json(result);
+	} catch (caughtError) {
+		if (caughtError instanceof PublishError) {
+			throw error(caughtError.status, caughtError.message);
+		}
+
+		throw error(500, 'Failed to save blog post.');
+	}
+};

--- a/src/routes/api/owner/session/+server.ts
+++ b/src/routes/api/owner/session/+server.ts
@@ -9,7 +9,6 @@ export const GET: RequestHandler = ({ locals }) => {
 		isOwner: locals.isOwner,
 		owner: locals.owner,
 		authConfigured: isOwnerAuthConfigured(),
-		publishConfigured: publishStatus.contentRepoConfigured,
-		deployConfigured: publishStatus.deployHookConfigured
+		publishConfigured: publishStatus.contentRepoConfigured
 	});
 };

--- a/src/routes/api/owner/session/+server.ts
+++ b/src/routes/api/owner/session/+server.ts
@@ -1,0 +1,15 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { getBlogPublishStatus } from '$lib/server/blog-publishing';
+import { isOwnerAuthConfigured } from '$lib/server/owner-session';
+
+export const GET: RequestHandler = ({ locals }) => {
+	const publishStatus = getBlogPublishStatus();
+
+	return json({
+		isOwner: locals.isOwner,
+		owner: locals.owner,
+		authConfigured: isOwnerAuthConfigured(),
+		publishConfigured: publishStatus.contentRepoConfigured,
+		deployConfigured: publishStatus.deployHookConfigured
+	});
+};

--- a/src/routes/owner/+page.svelte
+++ b/src/routes/owner/+page.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type OwnerStatus = {
+		isOwner: boolean;
+		owner: {
+			login: string;
+			name: string | null;
+			avatarUrl: string | null;
+		} | null;
+		authConfigured: boolean;
+		publishConfigured: boolean;
+		deployConfigured: boolean;
+	};
+
+	let ownerStatus: OwnerStatus | null = null;
+	let loading = true;
+	let errorMessage = '';
+
+	const searchParams =
+		typeof window === 'undefined'
+			? new URLSearchParams()
+			: new URLSearchParams(window.location.search);
+	const ownerErrorCode = searchParams.get('error');
+
+	const errorLabels: Record<string, string> = {
+		'auth-not-configured': 'GitHub owner authentication is not configured yet.',
+		'invalid-state': 'The GitHub sign-in session expired. Please try again.',
+		'token-exchange-failed': 'GitHub sign-in could not finish. Please try again.',
+		'github-user-fetch-failed': 'GitHub returned an unexpected response while signing in.',
+		'owner-not-authorized': 'The signed-in GitHub account is not allowed to edit this site.'
+	};
+
+	if (ownerErrorCode) {
+		errorMessage = errorLabels[ownerErrorCode] ?? 'Owner sign-in failed.';
+	}
+
+	onMount(async () => {
+		try {
+			const response = await fetch('/api/owner/session');
+			if (!response.ok) {
+				throw new Error('Failed to load owner status.');
+			}
+
+			ownerStatus = (await response.json()) as OwnerStatus;
+		} catch (caughtError) {
+			errorMessage =
+				caughtError instanceof Error ? caughtError.message : 'Failed to load owner status.';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Owner</title>
+</svelte:head>
+
+<div class="owner-page">
+	<div class="owner-card">
+		<p class="owner-kicker">Owner mode</p>
+		<h1 class="owner-title">Edit the site’s blog content from here.</h1>
+		<p class="owner-copy">
+			Sign in once with GitHub, then open any blog post and the inline edit button will appear for
+			your session.
+		</p>
+
+		{#if errorMessage}
+			<p class="owner-error">{errorMessage}</p>
+		{/if}
+
+		{#if loading}
+			<p class="owner-status">Checking owner session…</p>
+		{:else if ownerStatus}
+			<div class="owner-status-group">
+				<p class="owner-status-row">
+					<span>Authentication</span>
+					<strong>{ownerStatus.authConfigured ? 'Ready' : 'Missing setup'}</strong>
+				</p>
+				<p class="owner-status-row">
+					<span>Content publishing</span>
+					<strong>{ownerStatus.publishConfigured ? 'Ready' : 'Missing setup'}</strong>
+				</p>
+				<p class="owner-status-row">
+					<span>Vercel deploy hook</span>
+					<strong>{ownerStatus.deployConfigured ? 'Ready' : 'Optional / missing'}</strong>
+				</p>
+			</div>
+
+			{#if ownerStatus.isOwner}
+				<p class="owner-status">
+					Signed in as <strong>{ownerStatus.owner?.name || ownerStatus.owner?.login}</strong>
+				</p>
+				<div class="owner-actions">
+					<a class="owner-button primary" href="/blog">Open the blog</a>
+					<a class="owner-button secondary" href="/api/auth/logout?redirectTo=/owner">Sign out</a>
+				</div>
+			{:else}
+				<div class="owner-actions">
+					<a class="owner-button primary" href="/api/auth/github?redirectTo=/blog">
+						Sign in with GitHub
+					</a>
+				</div>
+			{/if}
+		{/if}
+	</div>
+</div>
+
+<style>
+	.owner-page {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		background: var(--color-bg);
+		padding: 7rem 1.5rem 3rem;
+		min-height: 100vh;
+	}
+
+	.owner-card {
+		border: 1px solid var(--color-content-border);
+		background: var(--color-content-bg);
+		padding: 2rem;
+		width: min(100%, 40rem);
+		color: var(--color-content-text);
+	}
+
+	.owner-kicker {
+		margin: 0 0 0.75rem;
+		color: var(--color-content-secondary);
+		font-size: var(--content-font-size-body-sm);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.owner-title {
+		margin: 0 0 1rem;
+		color: var(--color-content-heading);
+		font-size: clamp(2rem, 4vw, 3.5rem);
+		line-height: 1;
+		font-family: var(--font-serif);
+	}
+
+	.owner-copy,
+	.owner-status,
+	.owner-error,
+	.owner-status-row {
+		font-size: var(--content-font-size-body);
+		line-height: 1.6;
+	}
+
+	.owner-copy {
+		margin: 0 0 1.5rem;
+	}
+
+	.owner-error {
+		margin: 0 0 1rem;
+		color: var(--color-content-link);
+	}
+
+	.owner-status-group {
+		margin-bottom: 1.5rem;
+		border-top: 1px solid var(--color-content-border);
+		border-bottom: 1px solid var(--color-content-border);
+		padding: 1rem 0;
+	}
+
+	.owner-status-row {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		margin: 0;
+	}
+
+	.owner-status-row + .owner-status-row {
+		margin-top: 0.5rem;
+	}
+
+	.owner-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		margin-top: 1.5rem;
+	}
+
+	.owner-button {
+		display: inline-flex;
+		justify-content: center;
+		align-items: center;
+		padding: 0.85rem 1.25rem;
+		text-decoration: none;
+	}
+
+	.owner-button.primary {
+		background: var(--color-content-text);
+		color: var(--color-content-bg);
+	}
+
+	.owner-button.secondary {
+		border: 1px solid var(--color-content-border);
+		color: var(--color-content-text);
+	}
+
+	@media (max-width: 640px) {
+		.owner-page {
+			padding-top: 6rem;
+		}
+
+		.owner-card {
+			padding: 1.5rem;
+		}
+
+		.owner-status-row {
+			flex-direction: column;
+			gap: 0.15rem;
+		}
+	}
+</style>

--- a/src/routes/owner/+page.svelte
+++ b/src/routes/owner/+page.svelte
@@ -10,7 +10,6 @@
 		} | null;
 		authConfigured: boolean;
 		publishConfigured: boolean;
-		deployConfigured: boolean;
 	};
 
 	let ownerStatus: OwnerStatus | null = null;
@@ -80,10 +79,6 @@
 				<p class="owner-status-row">
 					<span>Content publishing</span>
 					<strong>{ownerStatus.publishConfigured ? 'Ready' : 'Missing setup'}</strong>
-				</p>
-				<p class="owner-status-row">
-					<span>Vercel deploy hook</span>
-					<strong>{ownerStatus.deployConfigured ? 'Ready' : 'Optional / missing'}</strong>
 				</p>
 			</div>
 


### PR DESCRIPTION
### Summary
Adds a GitHub OAuth-authenticated inline visual editor that lets the site owner edit blog posts directly on the site, with changes auto-pushed to the content repo and deployed via Vercel.

### Problem
There was no way to edit blog content directly from the site. Making changes required manually editing markdown files in the content repo, committing, and pushing — with no live preview of how the rendered content would look.

### Solution
Implemented a full owner authentication flow using GitHub OAuth, a session-based "owner mode" that surfaces an edit button on blog posts, and a save pipeline that commits updated markdown directly to the `teenylilcontent` GitHub repo. The editor renders markdown as close to the final rendered output as possible, so the author edits the live-looking content rather than a raw source pane.

### Key Changes
- **Owner authentication** — GitHub OAuth flow (`/api/auth/github`, `/api/auth/callback/github`, `/api/auth/logout`) with a signed session cookie; only the configured GitHub login is allowed in
- **Server hooks** — `hooks.server.ts` reads the owner session on every request and populates `locals.owner` / `locals.isOwner`
- **Owner dashboard** — `/owner` page shows auth/publish config status, sign-in/sign-out actions, and friendly error messages for failed OAuth flows
- **Blog source utilities** — `blog-source.ts` handles frontmatter parsing, serialization, checksum generation, and reading markdown files from disk
- **Content API** — `GET /api/content/blog/[slug]` loads a post's raw markdown; `POST /api/content/blog/[slug]/save` validates, serializes, and publishes changes to GitHub (owner-only, checksum-guarded)
- **Blog publishing** — server-side module commits updated markdown to the content repo via the GitHub API using a write token; no separate deploy hook needed since Vercel auto-deploys on push
- **Markdown rendering** — `render-markdown.ts` and `blog-markdown-content.svelte` render markdown to HTML with syntax highlighting, inline video support, TOC, and sub/superscript — used for the live-preview editing experience
- **Environment variables** — `.env.example` updated with all required owner auth and content publishing vars (`OWNER_SESSION_SECRET`, `GITHUB_OAUTH_CLIENT_ID/SECRET`, `CONTENT_REPO_*`, `GITHUB_WRITE_TOKEN`)


---

<a href="https://builder.io/app/projects/4bf0f5dccbe548cbbe70edee08807ec5/finder-peak-epzdvfwm"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://4bf0f5dccbe548cbbe70edee08807ec5-finder-peak-epzdvfwm_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<h3>Preview</h3>
<img src="https://cdn.builder.io/o/assets%2F7055d8d0cc284adcbfeafeb0f4b74e06%2Fdf71ef9000b2423ea6162960bc91a952?alt=media&token=29b58c79-f1d2-480d-8fd7-42a341a39636&apiKey=7055d8d0cc284adcbfeafeb0f4b74e06" alt="Changes preview" style="max-width: 100%; height: auto;">
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 146`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4bf0f5dccbe548cbbe70edee08807ec5</projectId>-->
<!--<branchName>finder-peak-epzdvfwm</branchName>-->